### PR TITLE
RingMPICUDA: Remove its own routine to get local rank size

### DIFF
--- a/src/mpi_cuda/CMakeLists.txt
+++ b/src/mpi_cuda/CMakeLists.txt
@@ -11,6 +11,10 @@ set_full_path(THIS_DIR_HEADERS
   util.hpp
   )
 
+set_full_path(THIS_DIR_CXX_SOURCES
+  communicator.cpp
+  )
+
 set_full_path(THIS_DIR_CUDA_SOURCES
   cuda_kernels.cu
   )

--- a/src/mpi_cuda/communicator.cpp
+++ b/src/mpi_cuda/communicator.cpp
@@ -25,32 +25,24 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#include "cudacommunicator.hpp"
+#include "Al.hpp"
+#include "mpi_cuda/communicator.hpp"
+#include "mpi_cuda/allreduce_ring.hpp"
 
 namespace Al {
 namespace internal {
 namespace mpi_cuda {
 
-class RingMPICUDA;
+RingMPICUDA &MPICUDACommunicator::get_ring() {
+  if (!m_ring)
+    m_ring = new RingMPICUDA(*this);
+  return *m_ring;
+}
 
-class MPICUDACommunicator: public CUDACommunicator {
- public:
-  MPICUDACommunicator() : MPICUDACommunicator(MPI_COMM_WORLD, 0) {}
-  MPICUDACommunicator(cudaStream_t stream_) :
-    MPICUDACommunicator(MPI_COMM_WORLD, stream_) {}
-  MPICUDACommunicator(MPI_Comm comm_, cudaStream_t stream_)
-    : CUDACommunicator(comm_, stream_), m_ring(nullptr) {
-  }
-
-  RingMPICUDA &get_ring();
-
-  ~MPICUDACommunicator();
-
- protected:
-  RingMPICUDA *m_ring;
-};
+MPICUDACommunicator::~MPICUDACommunicator() {
+  if (m_ring)
+    delete m_ring;
+}
 
 } // namespace mpi_cuda
 } // namespace internal

--- a/src/mpi_cuda/util.hpp
+++ b/src/mpi_cuda/util.hpp
@@ -131,22 +131,6 @@ MPI_Datatype get_mpi_data_type() {
   return mpi::TypeMap<T>();
 }
 
-inline int get_mpi_comm_local_size() {
-  char *env = getenv("MV2_COMM_WORLD_LOCAL_SIZE");
-  if (env == nullptr) {
-    env = getenv("OMPI_COMM_WORLD_LOCAL_SIZE");
-  }
-  if (env == nullptr) {
-    env = getenv("SLURM_NTASKS_PER_NODE");
-  }
-  if (env == nullptr) {
-    std::cerr << "Failed to determine the number of ranks per node" << std::endl;
-    abort();
-  }
-  int size = atoi(env);
-  return size;
-}
-
 class MPIPrintStream {
  public:
   MPIPrintStream(std::ostream &os, int rank): m_os(os) {


### PR DESCRIPTION
Note that I needed to recover communicator.cpp, which was deleted in Tom's #6, in order to resolve the mutual dependency between MPICUDACommunicator and RingMPICUDA.