### PR TITLE
CMake pthreads on cuda targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,20 @@ endif ()
 find_package(MPI 3.0 REQUIRED COMPONENTS CXX)
 
 # Fix the imported target
+
+# FIXME (trb): We should split the library into language-specific
+# targets. That is, the .cu files should never need MPI linkage or
+# OpenMP, so they should be built into a separate target without
+# MPI::MPI_CXX or OpenMP::OpenMP_CXX "linkage".
+get_target_property(
+  __mpi_compile_options MPI::MPI_CXX INTERFACE_COMPILE_OPTIONS)
+set_property(TARGET MPI::MPI_CXX PROPERTY
+  INTERFACE_COMPILE_OPTIONS
+  $<$<COMPILE_LANGUAGE:CXX>:${__mpi_compile_options}>)
+unset(__mpi_compile_options)
+
+# Assuming this target is excluded from all device-link steps, this
+# should not be necessary after the above FIXME is resolved.
 get_property(_TMP_MPI_LINK_LIBRARIES TARGET MPI::MPI_CXX
   PROPERTY INTERFACE_LINK_LIBRARIES)
 foreach(lib IN LISTS _TMP_MPI_LINK_LIBRARIES)


### PR DESCRIPTION
This just sets the compile language to C++ for the MPI::MPI_CXX INTERFACE_COMPILE_OPTIONS