### PR TITLE
FastEvent uses CUDA events

### DIFF
--- a/src/cuda.cpp
+++ b/src/cuda.cpp
@@ -109,6 +109,7 @@ bool stream_memory_operations_supported() {
 }
 
 FastEvent::FastEvent() {
+#if 0
   if (stream_memory_operations_supported()) {
     sync_event = get_pinned_memory<int32_t>(1);
     // Initialize to completed to match CUDA event semantics.
@@ -116,21 +117,27 @@ FastEvent::FastEvent() {
     AL_CHECK_CUDA_DRV(cuMemHostGetDevicePointer(
                         &sync_event_dev_ptr, sync_event, 0));
   }
-  else {
+  else
+#endif
+  {
     plain_event = get_cuda_event();
   }
 }
 
 FastEvent::~FastEvent() {
+#if 0
   if (stream_memory_operations_supported()) {
     release_pinned_memory(sync_event);
   }
-  else {
+  else
+#endif
+  {
     release_cuda_event(plain_event);
   }
 }
 
 void FastEvent::record(cudaStream_t stream) {
+#if 0
   if (stream_memory_operations_supported()) {
     // We cannot use std::atomic because we need the actual address of the memory.
     __atomic_store_n(sync_event, 0, __ATOMIC_SEQ_CST);
@@ -138,15 +145,20 @@ void FastEvent::record(cudaStream_t stream) {
                         stream, sync_event_dev_ptr, 1,
                         CU_STREAM_WRITE_VALUE_DEFAULT));
   }
-  else {
+  else
+#endif
+  {
     AL_CHECK_CUDA(cudaEventRecord(plain_event, stream));
   }
 }
 
 bool FastEvent::query() {
+#if 0
   if (stream_memory_operations_supported())
     return __atomic_load_n(sync_event, __ATOMIC_SEQ_CST);
-  else {
+  else
+#endif
+  {
     cudaError_t r = cudaEventQuery(plain_event);
     if (r == cudaSuccess)
       return true;

--- a/src/cuda.hpp
+++ b/src/cuda.hpp
@@ -140,6 +140,8 @@ bool stream_memory_operations_supported();
  * using the stream memory write operation.
  * This falls back to the usual CUDA events when stream memory operations are
  * not available.
+ * @note This is currently always falling back on CUDA events to work around a
+ * hang, the underlying cause of which has not been diagnosed.
  */
 class FastEvent {
  public:
@@ -153,8 +155,10 @@ class FastEvent {
   /** Return true if the event has completed. */
   bool query();
  private:
+#if 0
   int32_t* sync_event __attribute__((aligned(64)));
   CUdeviceptr sync_event_dev_ptr;
+#endif
   cudaEvent_t plain_event;
 };
 


### PR DESCRIPTION
This switches `FastEvent` to always use CUDA events.

There appears to be some sort of hang, the underlying causes of which I haven't been able to determine but which seems related to the stream memory operation implementation of events. Switching to regular CUDA events appears to avoid this.

This may add some slight overhead, but I do not expect it to be noticeable for allreduces. It may be more prominent for sends/recvs. On the other hand, hanging is infinite overhead.

I plan to revert this once we can actually figure out what's going on.