### PR TITLE
Check for hanging in MPIAlState

### DIFF
--- a/src/Al.hpp
+++ b/src/Al.hpp
@@ -37,6 +37,7 @@
 #include "Al_config.hpp"
 #include "base.hpp"
 #include "tuning_params.hpp"
+#include "utils.hpp"
 
 namespace Al {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_HEADERS
   mempool.hpp
   mpi_impl.hpp
   tuning_params.hpp
+  utils.hpp
   )
 set_full_path(THIS_DIR_CXX_SOURCES
   Al.cpp

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1,0 +1,41 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <chrono>
+
+namespace Al {
+
+/** Return time, in seconds (with decimal), since a fixed epoch. */
+inline double get_time() {                                                      
+  using namespace std::chrono;                                                  
+  return duration_cast<duration<double>>(                                       
+    steady_clock::now().time_since_epoch()).count();                            
+}
+
+}  // namespace Al


### PR DESCRIPTION
Set `AL_DEBUG_HANG_CHECK`, and `MPIAlState` will be able to (heuristically) check for hangs. I've found this useful enough in debugging that I think it's worth adding back.