### PR TITLE
Add automatic hang detection to the progress engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if (ALUMINUM_ENABLE_NCCL AND NOT ALUMINUM_ENABLE_CUDA)
   message(STATUS "NCCL support requested; enabling CUDA support, too.")
   set(ALUMINUM_ENABLE_CUDA ON)
 endif ()
+option(ALUMINUM_DEBUG_HANG_CHECK "Enable hang checking." OFF)
 
 if (ALUMINUM_ENABLE_CUDA
     AND NOT ALUMINUM_ENABLE_NCCL
@@ -48,6 +49,9 @@ endif ()
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   set(AL_DEBUG ON)
+endif ()
+if (ALUMINUM_DEBUG_HANG_CHECK)
+  set(AL_DEBUG_HANG_CHECK ON)
 endif ()
 
 # Setup CXX requirements

--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -9,3 +9,4 @@
 #endif
 
 #cmakedefine AL_DEBUG
+#cmakedefine AL_DEBUG_HANG_CHECK

--- a/src/mpi_impl.hpp
+++ b/src/mpi_impl.hpp
@@ -521,7 +521,7 @@ class MPIAlState : public AlState {
       double t = get_time();
       // Choice of 10 + rank is arbitrary, but seems reasonable.
       // The + rank part helps ensure printing from ranks isn't interleaved.
-      if (t - sr_start > 10.0 + rank) {
+      if (t - send_recv_start > 10.0 + rank) {
         std::cout << rank << ": Possible send/recv hang detected, tag=" << tag << std::endl;
         hang_reported = true;
       }

--- a/src/progress.hpp
+++ b/src/progress.hpp
@@ -77,6 +77,7 @@ enum class RunType {
  * pre-allocated before enqueueing.
  */
 class AlState {
+  friend class ProgressEngine;
  public:
   /** Create with an associated request. */
   AlState(AlRequest req_) : req(req_) {}
@@ -104,6 +105,10 @@ class AlState {
   virtual bool blocks() const { return false; }
  private:
   AlRequest req;
+#ifdef AL_DEBUG_HANG_CHECK
+  bool hang_reported = false;
+  double start_time = std::numeric_limits<double>::max();
+#endif
 };
 
 /**


### PR DESCRIPTION
Enabled by building with -D ALUMINUM_DEBUG_HANG_CHECK=YES.

This partially overlaps with the hang checking the MPIAlState does, but that provides slightly more tailored information.