### PR TITLE
Profiling interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ if (ALUMINUM_ENABLE_NCCL AND NOT ALUMINUM_ENABLE_CUDA)
   set(ALUMINUM_ENABLE_CUDA ON)
 endif ()
 option(ALUMINUM_DEBUG_HANG_CHECK "Enable hang checking." OFF)
+option(ALUMINUM_ENABLE_NVPROF "Enable profiling via nvprof/NVTX." OFF)
 
 if (ALUMINUM_ENABLE_CUDA
     AND NOT ALUMINUM_ENABLE_NCCL
@@ -52,6 +53,10 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
 endif ()
 if (ALUMINUM_DEBUG_HANG_CHECK)
   set(AL_DEBUG_HANG_CHECK ON)
+endif ()
+if (ALUMINUM_ENABLE_NVPROF)
+  find_package(NVTX REQUIRED)
+  set(AL_HAS_NVPROF ON)
 endif ()
 
 # Setup CXX requirements

--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -10,3 +10,5 @@
 
 #cmakedefine AL_DEBUG
 #cmakedefine AL_DEBUG_HANG_CHECK
+
+#cmakedefine AL_HAS_NVPROF

--- a/cmake/FindNVTX.cmake
+++ b/cmake/FindNVTX.cmake
@@ -1,0 +1,32 @@
+# Sets the following variables
+#
+#   NVTX_FOUND
+#   NVTX_LIBRARY
+#
+# Defines the following imported target:
+#
+#   cuda::nvtx
+#
+
+find_library(NVTX_LIBRARY nvToolsExt
+  HINTS ${NVTX_DIR} $ENV{NVTX_DIR} ${CUDA_TOOLKIT_ROOT_DIR} ${CUDA_SDK_ROOT_DIR}
+  PATH_SUFFIXES lib64
+  DOC "The nvtx library."
+  NO_DEFAULT_PATH)
+find_library(NVTX_LIBRARY nvToolsExt)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NVTX
+  DEFAULT_MSG NVTX_LIBRARY)
+
+if (NOT TARGET cuda::nvtx)
+
+  add_library(cuda::nvtx INTERFACE IMPORTED)
+
+  set_property(TARGET cuda::nvtx PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES "${CUDA_INCLUDE_DIRS}")
+
+  set_property(TARGET cuda::nvtx PROPERTY
+    INTERFACE_LINK_LIBRARIES "${NVTX_LIBRARY}")
+
+endif (NOT TARGET cuda::nvtx)

--- a/src/Al.hpp
+++ b/src/Al.hpp
@@ -38,6 +38,7 @@
 #include "base.hpp"
 #include "tuning_params.hpp"
 #include "utils.hpp"
+#include "profiling.hpp"
 
 namespace Al {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,12 +5,14 @@ set_full_path(THIS_DIR_HEADERS
   base.hpp
   mempool.hpp
   mpi_impl.hpp
+  profiling.hpp
   tuning_params.hpp
   utils.hpp
   )
 set_full_path(THIS_DIR_CXX_SOURCES
   Al.cpp
   mpi_impl.cpp
+  profiling.cpp
   progress.cpp
   )
 
@@ -48,7 +50,8 @@ target_include_directories(Al PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/aluminum>)
 target_link_libraries(Al PUBLIC
   MPI::MPI_CXX HWLOC::hwloc OpenMP::OpenMP_CXX
-  $<$<BOOL:${AL_HAS_CUDA}>:cuda::cuda>)
+  $<$<BOOL:${AL_HAS_CUDA}>:cuda::cuda>
+  $<$<BOOL:${AL_HAS_NVPROF}>:cuda::nvtx>)
 target_compile_features(Al PUBLIC cxx_std_11)
 
 install(TARGETS Al

--- a/src/cuda.cpp
+++ b/src/cuda.cpp
@@ -52,6 +52,8 @@ void init(int&, char**&) {
   // Initialize internal streams.
   for (int i = 0; i < num_internal_streams; ++i) {
     AL_CHECK_CUDA(cudaStreamCreate(&internal_streams[i]));
+    profiling::name_stream(internal_streams[i],
+                           "al_internal_" + std::to_string(i));
   }
   // Check whether stream memory operations are supported.
   CUdevice dev;

--- a/src/mpi_cuda/allgather.hpp
+++ b/src/mpi_cuda/allgather.hpp
@@ -114,6 +114,8 @@ public:
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
 
+  std::string get_name() const override { return "HTAllgather"; }
+
 private:
   T* host_mem_;
   size_t count_;

--- a/src/mpi_cuda/allreduce.hpp
+++ b/src/mpi_cuda/allreduce.hpp
@@ -132,6 +132,8 @@ class HostTransferState : public AlState {
   }
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
+
+  std::string get_name() const override { return "HTAllreduce"; }
  private:
   T* host_mem;
   mpi::MPIAlState<T>* host_ar;

--- a/src/mpi_cuda/alltoall.hpp
+++ b/src/mpi_cuda/alltoall.hpp
@@ -103,6 +103,8 @@ public:
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
 
+  std::string get_name() const override { return "HTAlltoall"; }
+
 private:
   T* host_mem_;
   size_t count_;

--- a/src/mpi_cuda/bcast.hpp
+++ b/src/mpi_cuda/bcast.hpp
@@ -112,6 +112,8 @@ public:
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
 
+  std::string get_name() const override { return "HTBcast"; }
+
 private:
   int rank_;
   int root_;

--- a/src/mpi_cuda/gather.hpp
+++ b/src/mpi_cuda/gather.hpp
@@ -128,6 +128,8 @@ public:
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
 
+  std::string get_name() const override { return "HTGather"; }
+
 private:
   int rank_;
   int root_;

--- a/src/mpi_cuda/pt2pt.hpp
+++ b/src/mpi_cuda/pt2pt.hpp
@@ -74,6 +74,7 @@ class SendAlState : public AlState {
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
   RunType get_run_type() const override { return RunType::unbounded; }
+  std::string get_name() const override { return "HTSend"; }
  private:
   T* mem;
   size_t count;
@@ -122,6 +123,7 @@ class RecvAlState : public AlState {
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
   RunType get_run_type() const override { return RunType::unbounded; }
+  std::string get_name() const override { return "HTRecv"; }
  private:
   T* mem;
   size_t count;
@@ -162,6 +164,7 @@ class SendRecvAlState : public AlState {
     return send_state.get_compute_stream();
   }
   RunType get_run_type() const override { return RunType::unbounded; }
+  std::string get_name() const override { return "HTSendRecv"; }
  private:
   SendAlState<T> send_state;
   RecvAlState<T> recv_state;

--- a/src/mpi_cuda/pt2pt.hpp
+++ b/src/mpi_cuda/pt2pt.hpp
@@ -103,6 +103,7 @@ class RecvAlState : public AlState {
     release_pinned_memory(mem);
   }
   void start() override {
+    AlState::start();
     MPI_Irecv(mem, count, mpi::TypeMap<T>(), src, pt2pt_tag, comm, &req);
   }
   bool step() override {
@@ -143,6 +144,7 @@ class SendRecvAlState : public AlState {
     send_state(sendbuf, send_count, dest, comm, stream),
     recv_state(recvbuf, recv_count, src, comm, stream) {}
   void start() override {
+    AlState::start();
     send_state.start();
     recv_state.start();
   }

--- a/src/mpi_cuda/reduce.hpp
+++ b/src/mpi_cuda/reduce.hpp
@@ -115,6 +115,7 @@ public:
 
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
+  std::string get_name() const override { return "HTReduce"; }
 
 private:
   int rank_;

--- a/src/mpi_cuda/reduce_scatter.hpp
+++ b/src/mpi_cuda/reduce_scatter.hpp
@@ -99,6 +99,7 @@ public:
 
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
+  std::string get_name() const override { return "HTReduceScatter"; }
 
 private:
   size_t count_;

--- a/src/mpi_cuda/rma_ipc.hpp
+++ b/src/mpi_cuda/rma_ipc.hpp
@@ -43,6 +43,7 @@ class NotifyState: public AlState {
               cudaEvent_t ev):
       AlState(req), m_peer(peer), m_comm(comm), m_ev(ev) {}
   void start() override {
+    AlState::start();
     AL_CHECK_CUDA(cudaEventRecord(m_ev, m_comm.get_stream()));
     MPI_Isend(&key, 1, MPI_INT, m_peer, 0,
               m_comm.get_comm(), &m_requests[0]);
@@ -70,6 +71,7 @@ class WaitState: public AlState {
       m_ev_peer(ev_peer),
       m_stream_wait_set(false) {}
   void start() override {
+    AlState::start();
     MPI_Irecv(&key, 1, MPI_INT, m_peer, 0,
               m_comm.get_comm(), &m_req);
   }
@@ -107,6 +109,7 @@ class SyncState: public AlState {
       m_ev_self(ev_self), m_ev_peer(ev_peer),
       m_stream_wait_set(false) {}
   void start() override {
+    AlState::start();
     AL_CHECK_CUDA(cudaEventRecord(m_ev_self, m_comm.get_stream()));
     MPI_Isend(&key, 1, MPI_INT, m_peer, 0,
               m_comm.get_comm(), &m_requests[0]);

--- a/src/mpi_cuda/scatter.hpp
+++ b/src/mpi_cuda/scatter.hpp
@@ -128,6 +128,7 @@ public:
 
   bool needs_completion() const override { return false; }
   void* get_compute_stream() const override { return compute_stream; }
+  std::string get_name() const override { return "HTScatter"; }
 
 private:
   int rank_;

--- a/src/mpi_impl.hpp
+++ b/src/mpi_impl.hpp
@@ -573,6 +573,7 @@ class MPIPassthroughAlState : public MPIAlState<T> {
     }
     return false;
   }
+  std::string get_name() const override { return "MPIPassthrough"; }
  private:
   MPI_Op mpi_op;
   MPI_Request mpi_req;
@@ -747,6 +748,7 @@ class MPIRecursiveDoublingAlState : public MPIAlState<T> {
     }
     return false;
   }
+  std::string get_name() const override { return "MPIRecursiveDoubling"; }
  private:
   /** Mask for computing partners in each step. */
   unsigned int mask = 1;
@@ -1024,6 +1026,7 @@ class MPIRingAlState : public MPIAlState<T> {
       return ag_step();
     }
   }
+  std::string get_name() const override { return "MPIRing"; }
  private:
   /** 0 == reduce-scatter, 1 == allgather. */
   int phase = 0;
@@ -1369,6 +1372,7 @@ class MPIRabenseifnerAlState : public MPIAlState<T> {
       }
     }
   }
+  std::string get_name() const override { return "MPIRabenseifner"; }
  private:
   /** 0 == reduce-scatter, 1 == allgather. */
   int phase = 0;

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -1,0 +1,70 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "profiling.hpp"
+
+namespace Al {
+namespace internal {
+namespace profiling {
+
+void name_thread(std::thread::native_handle_type handle, std::string name) {
+#ifdef AL_HAS_NVPROF
+  nvtxNameOsThreadA(handle, name.c_str());
+#endif
+}
+
+#ifdef AL_HAS_CUDA
+void name_stream(cudaStream_t stream, std::string name) {
+#ifdef AL_HAS_NVPROF
+  nvtxNameCudaStreamA(stream, name.c_str());
+#endif  
+}
+#endif
+
+void mark(std::string desc) {
+#ifdef AL_HAS_NVPROF
+  nvtxMarkA(desc.c_str());
+#endif
+}
+
+ProfileRange prof_start(std::string name) {
+  ProfileRange range;
+#ifdef AL_HAS_NVPROF
+  range.nvtx_range = nvtxRangeStartA(name.c_str());
+#endif
+  return range;
+}
+
+void prof_end(ProfileRange range) {
+#ifdef AL_HAS_NVPROF
+  nvtxRangeEnd(range.nvtx_range);
+#endif
+}
+
+}  // namespace profiling
+}  // namespace internal
+}  // namespace Al

--- a/src/profiling.hpp
+++ b/src/profiling.hpp
@@ -30,7 +30,7 @@
 #include <thread>
 #include <string>
 
-#include "Al.hpp"
+#include "Al_config.hpp"
 
 #ifdef AL_HAS_NVPROF
 #include <nvToolsExt.h>
@@ -38,7 +38,8 @@
 #include <nvToolsExtCudaRt.h>
 #endif
 #ifdef AL_HAS_CUDA
-#include "cuda.hpp"
+#include <cuda.h>
+#include <cuda_runtime.h>
 #endif
 
 namespace Al {

--- a/src/profiling.hpp
+++ b/src/profiling.hpp
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <thread>
+#include <string>
+
+#include "Al.hpp"
+
+#ifdef AL_HAS_NVPROF
+#include <nvToolsExt.h>
+#include <nvToolsExtCuda.h>
+#include <nvToolsExtCudaRt.h>
+#endif
+#ifdef AL_HAS_CUDA
+#include "cuda.hpp"
+#endif
+
+namespace Al {
+namespace internal {
+namespace profiling {
+
+/** Assign a name to the thread given by handle. */
+void name_thread(std::thread::native_handle_type handle, std::string name);
+#ifdef AL_HAS_CUDA
+/** Assign a name to a CUDA stream. */
+void name_stream(cudaStream_t stream, std::string name);
+#endif
+
+/** Create an instantaneous marker. */
+void mark(std::string desc);
+
+/** Represent a range for profiling. */
+struct ProfileRange {
+#ifdef AL_HAS_NVPROF
+  nvtxRangeId_t nvtx_range;
+#endif
+};
+
+/** Start a profiling region with name. */
+ProfileRange prof_start(std::string name);
+/** End a profiling region. */
+void prof_end(ProfileRange range);
+
+}  // namespace profiling
+}  // namespace internal
+}  // namespace Al

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -73,6 +73,7 @@ void ProgressEngine::run() {
   cur_device = device;
 #endif
   thread = std::thread(&ProgressEngine::engine, this);
+  profiling::name_thread(thread.native_handle(), "al-progress");
   // Wait for the progress engine to start.
   std::unique_lock<std::mutex> lock(startup_mutex);
   startup_cv.wait(lock, [this] {return started_flag.load() == true;});

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -48,6 +48,14 @@ hwloc_obj_t hwloc_get_numanode_obj_by_os_index(hwloc_topology_t topology, unsign
 namespace Al {
 namespace internal {
 
+AlState::~AlState() {
+  profiling::prof_end(prof_range);
+}
+
+void AlState::start() {
+  prof_range = profiling::prof_start("AlState");
+}
+
 AlRequest get_free_request() {
   return std::make_shared<std::atomic<bool>>(false);
 }

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -53,7 +53,7 @@ AlState::~AlState() {
 }
 
 void AlState::start() {
-  prof_range = profiling::prof_start("AlState");
+  prof_range = profiling::prof_start(get_name());
 }
 
 AlRequest get_free_request() {
@@ -272,7 +272,7 @@ void ProgressEngine::engine() {
           if (t - req->start_time > 10.0 + world_comm->rank()) {
             std::cout << world_comm->rank()
                       << ": Progress engine detected a possible hang"
-                      << " state=" << req
+                      << " state=" << req << " " << req->get_name()
                       << " compute_stream=" << req->get_compute_stream()
                       << " run_type="
                       << (req->get_run_type() == RunType::bounded ? "bounded" : "unbounded")

--- a/src/progress.hpp
+++ b/src/progress.hpp
@@ -107,6 +107,8 @@ class AlState {
   virtual RunType get_run_type() const { return RunType::bounded; }
   /** True if this is meant to block operations until completion. */
   virtual bool blocks() const { return false; }
+  /** Return a name identifying the state (for debugging/info purposes). */
+  virtual std::string get_name() const { return "AlState"; }
  private:
   AlRequest req;
 #ifdef AL_DEBUG_HANG_CHECK

--- a/src/progress.hpp
+++ b/src/progress.hpp
@@ -46,6 +46,10 @@ namespace Al {
 class Communicator;
 
 namespace internal {
+// Forward declaration.
+namespace profiling {
+struct ProfileRange;
+}
 
 /**
  * Request handle for non-blocking operations.
@@ -81,12 +85,12 @@ class AlState {
  public:
   /** Create with an associated request. */
   AlState(AlRequest req_) : req(req_) {}
-  virtual ~AlState() {}
+  virtual ~AlState();
   /**
    * Perform initial setup of the algorithm.
    * This is called by the progress engine when the operation begins execution.
    */
-  virtual void start() {}
+  virtual void start();
   /**
    * Run one step of the algorithm.
    * Return true if the operation has completed, false if it has more steps
@@ -109,6 +113,7 @@ class AlState {
   bool hang_reported = false;
   double start_time = std::numeric_limits<double>::max();
 #endif
+  profiling::ProfileRange prof_range;
 };
 
 /**


### PR DESCRIPTION
Add a basic profiling interface and support for NVTX/nvprof profiling.

Enable via `-D ALUMINUM_ENABLE_NVPROF=YES`.