### PR TITLE
Configure use of stream mem ops by a CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ if (ALUMINUM_ENABLE_NCCL AND NOT ALUMINUM_ENABLE_CUDA)
 endif ()
 option(ALUMINUM_DEBUG_HANG_CHECK "Enable hang checking." OFF)
 option(ALUMINUM_ENABLE_NVPROF "Enable profiling via nvprof/NVTX." OFF)
+option(ALUMINUM_ENABLE_STREAM_MEM_OPS "Enable stream memory operations." OFF)
 
 if (ALUMINUM_ENABLE_CUDA
     AND NOT ALUMINUM_ENABLE_NCCL
@@ -57,6 +58,9 @@ endif ()
 if (ALUMINUM_ENABLE_NVPROF)
   find_package(NVTX REQUIRED)
   set(AL_HAS_NVPROF ON)
+endif ()
+if (ALUMINUM_ENABLE_STREAM_MEM_OPS)
+  set(AL_USE_STREAM_MEM_OPS ON)
 endif ()
 
 # Setup CXX requirements

--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -12,3 +12,6 @@
 #cmakedefine AL_DEBUG_HANG_CHECK
 
 #cmakedefine AL_HAS_NVPROF
+
+/** Whether to use stream memory operations (if supported). */
+#cmakedefine01 AL_USE_STREAM_MEM_OPS

--- a/src/tuning_params.hpp
+++ b/src/tuning_params.hpp
@@ -58,6 +58,3 @@
 
 /** Amount of sync object memory to preallocate in the pool. */
 #define AL_SYNC_MEM_PREALLOC 1024
-
-/** Whether to use stream memory operations (if supported). */
-#define AL_USE_STREAM_MEM_OPS 0


### PR DESCRIPTION
This makes it easier to enable the stream memory operation.