### PR TITLE
Improved benchmarks and debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(ALUMINUM_DEBUG_HANG_CHECK "Enable hang checking." OFF)
 option(ALUMINUM_ENABLE_NVPROF "Enable profiling via nvprof/NVTX." OFF)
 option(ALUMINUM_ENABLE_STREAM_MEM_OPS "Enable stream memory operations." OFF)
 option(ALUMINUM_HT_USE_PASSTHROUGH "Host-transfer allreduces use MPI directly." OFF)
+option(ALUMINUM_ENABLE_TRACE "Enable runtime tracing." OFF)
 
 if (ALUMINUM_ENABLE_CUDA
     AND NOT ALUMINUM_ENABLE_NCCL
@@ -70,6 +71,9 @@ if (ALUMINUM_ENABLE_STREAM_MEM_OPS)
 endif ()
 if (ALUMINUM_HT_USE_PASSTHROUGH)
   set(AL_HT_USE_PASSTHROUGH ON)
+endif ()
+if (ALUMINUM_ENABLE_TRACE)
+  set(AL_TRACE ON)
 endif ()
 
 # Setup CXX requirements

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(BENCHMARK_SRCS
+  benchmark_allgather.cpp
   benchmark_allreduces.cpp
   benchmark_nballreduces.cpp
+  benchmark_reduce_scatter.cpp
   benchmark_reductions.cpp)
 
 foreach(src ${BENCHMARK_SRCS})

--- a/benchmark/benchmark_allgather.cpp
+++ b/benchmark/benchmark_allgather.cpp
@@ -46,7 +46,7 @@ void time_allgather_algo(typename VectorType<Backend>::type input,
                          CollectiveProfile<Backend, typename Backend::allgather_algo_type>& prof) {
   const size_t recv_size = input.size() * comm.size();
   auto recv = get_vector<Backend>(recv_size);
-  auto in_place_input(input);
+  auto in_place_input(recv);
   for (size_t trial = 0; trial < num_trials + 1; ++trial) {
     MPI_Barrier(MPI_COMM_WORLD);
     start_timer<Backend>(comm);

--- a/benchmark/benchmark_allgather.cpp
+++ b/benchmark/benchmark_allgather.cpp
@@ -40,17 +40,17 @@ size_t max_size = 1<<28;
 const size_t num_trials = 20;
 
 template <typename Backend>
-void time_allreduce_algo(typename VectorType<Backend>::type input,
+void time_allgather_algo(typename VectorType<Backend>::type input,
                          typename Backend::comm_type& comm,
-                         typename Backend::allreduce_algo_type algo,
-                         CollectiveProfile<Backend, typename Backend::allreduce_algo_type>& prof) {
-  auto recv = get_vector<Backend>(input.size());
+                         typename Backend::allgather_algo_type algo,
+                         CollectiveProfile<Backend, typename Backend::allgather_algo_type>& prof) {
+  const size_t recv_size = input.size() * comm.size();
+  auto recv = get_vector<Backend>(recv_size);
   auto in_place_input(input);
   for (size_t trial = 0; trial < num_trials + 1; ++trial) {
     MPI_Barrier(MPI_COMM_WORLD);
     start_timer<Backend>(comm);
-    Al::Allreduce<Backend>(input.data(), recv.data(), input.size(),
-                           Al::ReductionOperator::sum, comm, algo);
+    Al::Allgather<Backend>(input.data(), recv.data(), input.size(), comm, algo);
     if (trial > 0) {  // Skip warmup.
       prof.add_result(comm, input.size(), algo, false,
                       finish_timer<Backend>(comm));
@@ -58,8 +58,7 @@ void time_allreduce_algo(typename VectorType<Backend>::type input,
     in_place_input = input;
     MPI_Barrier(MPI_COMM_WORLD);
     start_timer<Backend>(comm);
-    Al::Allreduce<Backend>(in_place_input.data(), input.size(),
-                           Al::ReductionOperator::sum, comm, algo);
+    Al::Allgather<Backend>(in_place_input.data(), input.size(), comm, algo);
     if (trial > 0) {  // Skip warmup.
       prof.add_result(comm, input.size(), algo, true,
                       finish_timer<Backend>(comm));
@@ -69,16 +68,16 @@ void time_allreduce_algo(typename VectorType<Backend>::type input,
 
 template <typename Backend>
 void do_benchmark(const std::vector<size_t> &sizes) {
-  std::vector<typename Backend::allreduce_algo_type> algos
-      = get_allreduce_algorithms<Backend>();
+  std::vector<typename Backend::allgather_algo_type> algos
+      = get_allgather_algorithms<Backend>();
   typename Backend::comm_type comm;  // Use COMM_WORLD.
-  CollectiveProfile<Backend, typename Backend::allreduce_algo_type> prof("allreduce");
+  CollectiveProfile<Backend, typename Backend::allgather_algo_type> prof("allgather");
   for (const auto& size : sizes) {
     auto data = gen_data<Backend>(size);
     // Benchmark algorithms.
     for (auto&& algo : algos) {
       MPI_Barrier(MPI_COMM_WORLD);
-      time_allreduce_algo<Backend>(data, comm, algo, prof);
+      time_allgather_algo<Backend>(data, comm, algo, prof);
     }
   }
   if (comm.rank() == 0) {
@@ -111,7 +110,8 @@ int main(int argc, char** argv) {
   std::vector<size_t> sizes = get_sizes(start_size, max_size);
   
   if (backend == "MPI") {
-    do_benchmark<Al::MPIBackend>(sizes);
+    std::cout << "Allgather not supported on MPI backend." << std::endl;
+    std::abort();
 #ifdef AL_HAS_NCCL
   } else if (backend == "NCCL") {
     do_benchmark<Al::NCCLBackend>(sizes);

--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -17,3 +17,5 @@
 #cmakedefine01 AL_USE_STREAM_MEM_OPS
 
 #cmakedefine AL_HT_USE_PASSTHROUGH
+
+#cmakedefine AL_TRACE

--- a/src/Al.hpp
+++ b/src/Al.hpp
@@ -39,6 +39,7 @@
 #include "tuning_params.hpp"
 #include "utils.hpp"
 #include "profiling.hpp"
+#include "trace.hpp"
 
 namespace Al {
 
@@ -103,6 +104,8 @@ void Allreduce(const T* sendbuf, T* recvbuf, size_t count,
                ReductionOperator op, typename Backend::comm_type& comm,
                typename Backend::allreduce_algo_type algo =
                Backend::allreduce_algo_type::automatic) {
+  internal::trace::record_op<Backend, T>("allreduce", comm, sendbuf, recvbuf,
+                                         count);
   Backend::template Allreduce<T>(sendbuf, recvbuf, count, op, comm, algo);
 }
 
@@ -119,6 +122,7 @@ void Allreduce(T* recvbuf, size_t count,
                ReductionOperator op, typename Backend::comm_type& comm,
                typename Backend::allreduce_algo_type algo =
                Backend::allreduce_algo_type::automatic) {
+  internal::trace::record_op<Backend, T>("allreduce", comm, recvbuf, count);
   Backend::template Allreduce<T>(recvbuf, count, op, comm, algo);
 }
 
@@ -138,6 +142,8 @@ void NonblockingAllreduce(
   typename Backend::req_type& req,
   typename Backend::allreduce_algo_type algo =
   Backend::allreduce_algo_type::automatic) {
+  internal::trace::record_op<Backend, T>("nonblocking-allreduce", comm, sendbuf,
+                                         recvbuf, count);
   Backend::template NonblockingAllreduce<T>(sendbuf, recvbuf, count, op,
                                             comm, req, algo);
 }
@@ -150,6 +156,8 @@ void NonblockingAllreduce(
   typename Backend::req_type& req,
   typename Backend::allreduce_algo_type algo =
   Backend::allreduce_algo_type::automatic) {
+  internal::trace::record_op<Backend, T>("nonblocking-allreduce", comm,
+                                         recvbuf, count);
   Backend::template NonblockingAllreduce<T>(recvbuf, count, op,
                                             comm, req, algo);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_HEADERS
   mempool.hpp
   mpi_impl.hpp
   profiling.hpp
+  trace.hpp
   tuning_params.hpp
   utils.hpp
   )
@@ -14,6 +15,7 @@ set_full_path(THIS_DIR_CXX_SOURCES
   mpi_impl.cpp
   profiling.cpp
   progress.cpp
+  trace.cpp
   )
 
 if (AL_HAS_CUDA)

--- a/src/mpi_cuda/allreduce.hpp
+++ b/src/mpi_cuda/allreduce.hpp
@@ -105,6 +105,7 @@ class HostTransferState : public AlState {
   }
 
   ~HostTransferState() {
+    delete host_ar;
     release_pinned_memory(host_mem);
   }
 
@@ -122,7 +123,6 @@ class HostTransferState : public AlState {
       // Wait for the allreduce to complete.
       if (host_ar->step()) {
         ar_done = true;
-        delete host_ar;  // TODO: Maybe move this.
         // Mark the sync as done to wake up the device.
         gpu_wait.signal();
       } else {
@@ -139,6 +139,9 @@ class HostTransferState : public AlState {
   void* get_compute_stream() const override { return compute_stream; }
 
   std::string get_name() const override { return "HTAllreduce"; }
+  std::string get_desc() const override {
+    return host_ar->get_desc();
+  }
  private:
   T* host_mem;
   mpi::MPIAlState<T>* host_ar;

--- a/src/mpi_cuda_impl.hpp
+++ b/src/mpi_cuda_impl.hpp
@@ -566,6 +566,7 @@ class MPICUDABackend {
     NonblockingScatter<T>(buffer, buffer, count, root, comm, req, algo);
   }
 
+  static std::string Name() { return "MPICUDABackend"; }
 
  private:
   /** Event for synchronizing between streams. */

--- a/src/mpi_impl.hpp
+++ b/src/mpi_impl.hpp
@@ -471,6 +471,13 @@ class MPIAlState : public AlState {
     }
     return false;
   }
+
+  std::string get_desc() const override {
+    return std::to_string(rank) + " "
+      + std::to_string(nprocs) + " "
+      + std::to_string(count) + " "
+      + std::to_string(tag);
+  }
  protected:
   /** Local rank. */
   int rank;
@@ -1725,6 +1732,8 @@ class MPIBackend {
     NonblockingAllreduce(internal::IN_PLACE<T>(), recvbuf, count, op, comm,
                          req, algo);
   }
+
+  static std::string Name() { return "MPIBackend"; }
 };
 
 template <>

--- a/src/nccl_impl.hpp
+++ b/src/nccl_impl.hpp
@@ -320,6 +320,8 @@ class NCCLBackend {
                               comm, req, algo);
   }
 
+  static std::string Name() { return "NCCLBackend"; }
+
  private:
   /** Event for synchronizing between streams. */
   static cudaEvent_t sync_event;

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -29,6 +29,7 @@
 #include <cstdlib>
 #include "Al.hpp"
 #include "progress.hpp"
+#include "trace.hpp"
 
 // For ancient versions of hwloc.
 #if HWLOC_API_VERSION < 0x00010b00
@@ -130,6 +131,35 @@ void ProgressEngine::wait_for_completion(AlRequest& req) {
   // Spin until the request has completed.
   while (!req->load(std::memory_order_acquire)) {}
   req = NULL_REQUEST;
+}
+
+std::ostream& ProgressEngine::dump_state(std::ostream& ss) {
+  // Note: This pulls *directly from internal state*.
+  // This is *not* thread safe, and stuff might blow up.
+  // You should only be dumping state where you don't care about that anyway.
+  const size_t run_queue_size = run_queue.size();
+  ss << "Run queue (" << run_queue_size << "):";
+  for (size_t i = 0; i < run_queue_size; ++i) {
+    ss << i << ": ";
+    if (run_queue[i]) {
+      ss << run_queue[i]->get_name() << " " << run_queue[i]->get_desc() << "\n";
+    } else {
+      ss << "(unknown)\n";
+    }
+  }
+  const size_t req_queue_size = num_input_streams.load();
+  ss << "Request queues (" << req_queue_size << "):";
+  for (size_t i = 0; i < req_queue_size; ++i) {
+    ss << i << ": blocked=" << request_queues[i].blocked;
+    const size_t front = request_queues[i].q.front.load();
+    const size_t back = request_queues[i].q.back.load();
+    ss << " front=" << front << " back=" << back << "\n";
+    for (size_t j = front; j < back; ++j) {
+      ss << "\t" << j << ": " << request_queues[i].q.data[j]->get_name()
+         << " " << request_queues[i].q.data[j]->get_desc() << "\n";
+    }
+  }
+  return ss;
 }
 
 void ProgressEngine::bind() {
@@ -239,6 +269,9 @@ void ProgressEngine::engine() {
 #ifdef AL_DEBUG_HANG_CHECK
             req->start_time = get_time();
 #endif
+#ifdef AL_TRACE
+            trace::record_pe_start(*req);
+#endif
             request_queues[i].q.pop_always();
             if (req->blocks()) {
               request_queues[i].blocked = true;
@@ -263,6 +296,9 @@ void ProgressEngine::engine() {
           request_queues[blocking_reqs[req]].blocked = false;
           blocking_reqs.erase(req);
         }
+#ifdef AL_TRACE
+        trace::record_pe_done(*req);
+#endif
         delete req;
         i = run_queue.erase(i);
       } else {

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -138,7 +138,7 @@ std::ostream& ProgressEngine::dump_state(std::ostream& ss) {
   // This is *not* thread safe, and stuff might blow up.
   // You should only be dumping state where you don't care about that anyway.
   const size_t run_queue_size = run_queue.size();
-  ss << "Run queue (" << run_queue_size << "):";
+  ss << "Run queue (" << run_queue_size << "):\n";
   for (size_t i = 0; i < run_queue_size; ++i) {
     ss << i << ": ";
     if (run_queue[i]) {
@@ -148,7 +148,7 @@ std::ostream& ProgressEngine::dump_state(std::ostream& ss) {
     }
   }
   const size_t req_queue_size = num_input_streams.load();
-  ss << "Request queues (" << req_queue_size << "):";
+  ss << "Request queues (" << req_queue_size << "):\n";
   for (size_t i = 0; i < req_queue_size; ++i) {
     ss << i << ": blocked=" << request_queues[i].blocked;
     const size_t front = request_queues[i].q.front.load();

--- a/src/progress.hpp
+++ b/src/progress.hpp
@@ -39,6 +39,7 @@
 #include <condition_variable>
 #include <queue>
 #include <algorithm>
+#include <ostream>
 
 namespace Al {
 
@@ -109,6 +110,8 @@ class AlState {
   virtual bool blocks() const { return false; }
   /** Return a name identifying the state (for debugging/info purposes). */
   virtual std::string get_name() const { return "AlState"; }
+  /** Return a string description of the state (for debugging/info purposes). */
+  virtual std::string get_desc() const { return ""; }
  private:
   AlRequest req;
 #ifdef AL_DEBUG_HANG_CHECK
@@ -124,6 +127,7 @@ class AlState {
  * (see Le, et al. "Correct and Efficient Bounded FIFO Queues").
  */
 class SPSCQueue {
+  friend class ProgressEngine;
  public:
   /**
    * Initialize the queue.
@@ -294,6 +298,12 @@ class ProgressEngine {
    * This will block the calling thread.
    */
   void wait_for_completion(AlRequest& req);
+
+  /**
+   * Best effort to dump progress engine state for debugging.
+   * State is written to ss.
+   */
+  std::ostream& dump_state(std::ostream& ss);
  private:
   /** The actual thread of execution. */
   std::thread thread;

--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <unistd.h>
+#include <limits.h>
+#include <iostream>
+#include <vector>
+#include <fstream>
+#include "Al.hpp"
+
+namespace Al {
+namespace internal {
+namespace trace {
+
+namespace {
+std::vector<std::string> trace_log;
+std::vector<std::string> pe_trace_log;
+}
+
+void save_trace_entry(std::string entry, bool progress) {
+  if (progress) {
+    pe_trace_log.push_back(entry);
+  } else {
+    trace_log.push_back(entry);
+  }
+}
+
+void record_pe_start(const AlState& state) {
+#ifdef AL_TRACE
+  std::stringstream ss;
+  ss << get_time() << ": PE START "
+     << state.get_name() << " "
+     << state.get_desc();
+  save_trace_entry(ss.str(), true);
+#else
+  (void) state;
+#endif
+}
+
+void record_pe_done(const AlState& state) {
+#ifdef AL_TRACE
+  std::stringstream ss;
+  ss << get_time() << ": PE DONE "
+     << state.get_name() << " "
+     << state.get_desc();
+  save_trace_entry(ss.str(), true);
+#else
+  (void) state;
+#endif
+}
+
+std::ostream& write_trace_log(std::ostream& os) {
+#ifdef AL_TRACE
+  os << "Trace:\n";
+  for (const auto& entry : trace_log) os << entry << "\n";
+  os << "Progress engine trace:\n";
+  for (const auto& entry : pe_trace_log) os << entry << "\n";
+  return os;
+#else
+  return os;
+#endif
+}
+
+void write_trace_to_file() {
+#ifdef AL_TRACE
+  char hostname[HOST_NAME_MAX];
+  gethostname(hostname, HOST_NAME_MAX);
+  pid_t pid = getpid();
+  std::string filename = std::string(hostname) + "." + std::to_string(pid)
+    + ".trace.txt";
+  std::ofstream trace_file(filename);
+  write_trace_log(trace_file);
+#endif
+}
+
+}  // namespace trace
+}  // namespace internal
+}  // namespace Al

--- a/src/trace.hpp
+++ b/src/trace.hpp
@@ -48,8 +48,8 @@ void save_trace_entry(std::string entry, bool progress = false);
 
 /** Record an operation to the trace log. */
 template <typename Backend, typename T, typename... Args>
-void record_op(std::string op, typename Backend::comm_type& comm, Args... args) {
 #ifdef AL_TRACE
+void record_op(std::string op, typename Backend::comm_type& comm, Args... args) {
   std::stringstream ss;
   ss << get_time() << ": "
      << Backend::Name() << " "
@@ -61,11 +61,11 @@ void record_op(std::string op, typename Backend::comm_type& comm, Args... args) 
   using expander = int[];
   (void) expander{0, (void(ss << " " << std::forward<Args>(args)), 0)...};
   save_trace_entry(ss.str(), false);
-#else
-  (void) op;
-  (void) comm;
-#endif
 }
+#else  // AL_TRACE
+void record_op(std::string, typename Backend::comm_type&, Args...) {
+}
+#endif  // AL_TRACE
 
 /** Record a progress engine operation start to the trace log. */
 void record_pe_start(const AlState& state);

--- a/src/trace.hpp
+++ b/src/trace.hpp
@@ -1,0 +1,82 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <string>
+#include <sstream>
+
+#include "Al_config.hpp"
+#include "utils.hpp"
+
+namespace Al {
+namespace internal {
+// Forward declaration.
+class AlState;
+namespace trace {
+
+/**
+ * Save entry to the trace log.
+ * progress is whether this comes from the progress engine, which is recorded
+ * separately.
+ */
+void save_trace_entry(std::string entry, bool progress = false);
+
+/** Record an operation to the trace log. */
+template <typename Backend, typename T, typename... Args>
+void record_op(std::string op, typename Backend::comm_type& comm, Args... args) {
+#ifdef AL_TRACE
+  std::stringstream ss;
+  ss << get_time() << ": "
+     << Backend::Name() << " "
+     << typeid(T).name() << " "
+     << op << " "
+     << comm.rank() << " " << comm.size() << " ";
+  // See:
+  // https://stackoverflow.com/questions/27375089/what-is-the-easiest-way-to-print-a-variadic-parameter-pack-using-stdostream
+  using expander = int[];
+  (void) expander{0, (void(ss << " " << std::forward<Args>(args)), 0)...};
+  save_trace_entry(ss.str(), false);
+#else
+  (void) op;
+  (void) comm;
+#endif
+}
+
+/** Record a progress engine operation start to the trace log. */
+void record_pe_start(const AlState& state);
+/** Record a progress engine operation completion to the trace log. */
+void record_pe_done(const AlState& state);
+
+/** Write trace logs to os. */
+std::ostream& write_trace_log(std::ostream& os);
+/** Write trace logs to hostname.pid.trace.txt. */
+void write_trace_to_file();
+
+}  // namespace trace
+}  // namespace internal
+}  // namespace Al

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -378,11 +378,11 @@ void print_stats(std::vector<double>& times) {
 }
 
 // Stores runs for profiling a collective.
-template <typename Backend>
+template <typename Backend, typename AlgoType>
 struct CollectiveProfile {
   CollectiveProfile(std::string coll_name_) : coll_name(coll_name_) {}
   void add_result(const typename Backend::comm_type& comm,
-                  size_t size, typename Backend::allreduce_algo_type algo,
+                  size_t size, AlgoType algo,
                   bool inplace, double t) {
     results.emplace_back(std::make_tuple(
                            comm.size(), comm.rank(), size, algo, inplace, t));
@@ -404,9 +404,12 @@ struct CollectiveProfile {
   }
   std::string coll_name;
   // Communicator size, rank, collective size, algorithm, inplace time.
-  // TODO: Generalize beyond allreduce algos.
-  std::vector<std::tuple<int, int, size_t,
-                         typename Backend::allreduce_algo_type, bool, double>>
+  std::vector<std::tuple<int,
+                         int,
+                         size_t,
+                         AlgoType,
+                         bool,
+                         double>>
                    results;
 };
 


### PR DESCRIPTION
Benchmarks:
* Adds benchmarks for reduce-scatter and allgather.
* Changes the output of allreduce (and RS/AG) benchmarks to be a table of every trial done on rank 0. This makes it easier to parse the output and see the complete distribution of timing.
* The size printed for reduce-scatter and allgather is the size of the input vector.

Debugging:
* This adds a trace interface for recording Aluminum calls and their arguments.
* Adds a method for dumping the progress engine's state.
* Adds a custom signal handler that will dump information on fatal signals. (Note, when using this with LBANN, you need to disable LBANN's signal handler, as it overrides Aluminum's.)
* Also dumps information when a hang is detected.