### PR TITLE
MPI error handler

### DIFF
--- a/src/Al.cpp
+++ b/src/Al.cpp
@@ -147,8 +147,10 @@ void handle_mpi_error(MPI_Comm* comm, int* error, ...) {
   ss << "MPI error " << *error
      << " on rank " << rank << " of " << size
      << ": " << error_str << "\n";
+  // Print a note about the error.
+  std::cerr << ss.str() << std::endl;
   dump_error(ss);
-  std::abort();
+  std::exit(1);
 }
 
 }


### PR DESCRIPTION
The default MPI error handler is typically bad, because it kills the application, but doesn't give you a stack trace. This adds a better error handler.