### PR TITLE
Update version compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ include(CMakePackageConfigHelpers)
 export(EXPORT AluminumTargets NAMESPACE AL:: FILE AluminumTargets.cmake)
 write_basic_package_version_file(
   "${CMAKE_BINARY_DIR}/AluminumConfigVersion.cmake" VERSION
-  ${ALUMINUM_VERSION} COMPATIBILITY AnyNewerVersion )
+  ${ALUMINUM_VERSION} COMPATIBILITY SameMinorVersion )
 
 set(INCLUDE_INSTALL_DIRS ${CMAKE_SOURCE_DIR}/src)
 set(LIB_INSTALL_DIR src)


### PR DESCRIPTION
To prepare for future API-breakage, this updates the version compatibility of Aluminum to require the same major and minor versions.