### PR TITLE
Always allow at least 1 collective on each stream to make progress

### DIFF
--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -261,7 +261,13 @@ void ProgressEngine::engine() {
           bool do_start = false;
           switch (req->get_run_type()) {
           case RunType::bounded:
-            if (num_bounded < AL_PE_NUM_CONCURRENT_OPS) {
+            // Move to the run queue if any of the following hold:
+            //   1. num_bounded < AL_PE_NUM_CONCURRENT_OPS.
+            //   2. The run_queue for this stream doesn't exist.
+            //   3. The run_queue for this stream's first stage is empty.
+            if (num_bounded < AL_PE_NUM_CONCURRENT_OPS
+                || !run_queues.count(req->get_compute_stream())
+                || !run_queues[req->get_compute_stream()][0].size()) {
               ++num_bounded;
               do_start = true;
             }


### PR DESCRIPTION
This allows the concurrent operation limit to be exceeded if a stream is not allowed to make progress, thereby clogging the CUDA scheduler.

I tried a simplistic alternative where the concurrent operation limit applied per stream, but there was a significant performance implication. This diff is far smaller and the performance hit is near-negligible (compared to the case where the stars align such that the tests run; obviously it's an infinite performance improvement over the deadlocked case...).