### PR TITLE
Vector collectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,17 @@ path/to/aluminum/source
 The `MPI`, `NCCL`/`RCCL`, and `HostTransfer` backends support the following operations, including non-blocking and in-place (where meaingful) versions:
 * Collectives:
   * Allgather
+  * Vector allgather
   * Allreduce
   * Alltoall
+  * Vector alltoall
   * Broadcast
   * Gather
+  * Vector gather
   * Reduce
   * ReduceScatter (the block, not vector, version)
   * Scatter
+  * Vector scatter
 * Point-to-point:
   * Send
   * Recv

--- a/include/aluminum/Al.hpp
+++ b/include/aluminum/Al.hpp
@@ -970,7 +970,7 @@ void NonblockingScatterv(
   internal::trace::record_op<Backend, T>("nonblocking-scatterv", comm,
                                          buffer, counts, displs, root);
   Backend::template NonblockingScatterv<T>(
-    buffer, counts, displs, root, comm, algo);
+    buffer, counts, displs, root, comm, req, algo);
 }
 
 /**

--- a/include/aluminum/mpi/CMakeLists.txt
+++ b/include/aluminum/mpi/CMakeLists.txt
@@ -1,5 +1,6 @@
 set_source_path(THIS_DIR_HEADERS
   allgather.hpp
+  allgatherv.hpp
   allreduce.hpp
   alltoall.hpp
   bcast.hpp

--- a/include/aluminum/mpi/allgatherv.hpp
+++ b/include/aluminum/mpi/allgatherv.hpp
@@ -1,0 +1,98 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "progress.hpp"
+#include "mpi/base_state.hpp"
+#include "mpi/communicator.hpp"
+#include "mpi/utils.hpp"
+
+namespace Al {
+namespace internal {
+namespace mpi {
+
+template <typename T>
+void passthrough_allgatherv(const T* sendbuf, T* recvbuf,
+                            std::vector<size_t> counts,
+                            std::vector<size_t> displs,
+                            MPICommunicator& comm) {
+  std::vector<int> counts_ = intify_size_t_vector(counts);
+  std::vector<int> displs_ = intify_size_t_vector(displs);
+  MPI_Allgatherv(buf_or_inplace(sendbuf), counts[comm.rank()], TypeMap<T>(),
+                 recvbuf, counts_.data(), displs_.data(), TypeMap<T>(),
+                 comm.get_comm());
+}
+
+template <typename T>
+class AllgathervAlState : public MPIState {
+public:
+  AllgathervAlState(const T* sendbuf_, T* recvbuf_,
+                    std::vector<size_t> counts_,
+                    std::vector<size_t> displs_,
+                    MPICommunicator& comm_, AlRequest req_) :
+    MPIState(req_),
+    sendbuf(sendbuf_), recvbuf(recvbuf_),
+    counts(intify_size_t_vector(counts_)),
+    displs(intify_size_t_vector(displs_)),
+    rank(comm_.rank()), comm(comm_.get_comm()) {}
+
+  ~AllgathervAlState() override {}
+
+  std::string get_name() const override { return "MPIAllgatherv"; }
+
+protected:
+  void start_mpi_op() override {
+    MPI_Iallgatherv(buf_or_inplace(sendbuf), counts[rank], TypeMap<T>(),
+                    recvbuf, counts.data(), displs.data(), TypeMap<T>(),
+                    comm, get_mpi_req());
+  }
+
+private:
+  const T* sendbuf;
+  T* recvbuf;
+  std::vector<int> counts;
+  std::vector<int> displs;
+  int rank;
+  MPI_Comm comm;
+};
+
+template <typename T>
+void passthrough_nb_allgatherv(const T* sendbuf, T* recvbuf,
+                               std::vector<size_t> counts,
+                               std::vector<size_t> displs,
+                               MPICommunicator& comm, AlRequest& req) {
+  req = internal::get_free_request();
+  internal::mpi::AllgathervAlState<T>* state =
+    new internal::mpi::AllgathervAlState<T>(
+      sendbuf, recvbuf, counts, displs, comm, req);
+  get_progress_engine()->enqueue(state);
+}
+
+}  // namespace mpi
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/mpi/alltoallv.hpp
+++ b/include/aluminum/mpi/alltoallv.hpp
@@ -1,0 +1,118 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "progress.hpp"
+#include "mpi/base_state.hpp"
+#include "mpi/communicator.hpp"
+#include "mpi/utils.hpp"
+
+namespace Al {
+namespace internal {
+namespace mpi {
+
+template <typename T>
+void passthrough_alltoallv(const T* sendbuf,
+                           std::vector<size_t> send_counts,
+                           std::vector<size_t> send_displs,
+                           T* recvbuf,
+                           std::vector<size_t> recv_counts,
+                           std::vector<size_t> recv_displs,
+                           MPICommunicator& comm) {
+  std::vector<int> send_counts_ = intify_size_t_vector(send_counts);
+  std::vector<int> send_displs_ = intify_size_t_vector(send_displs);
+  std::vector<int> recv_counts_ = intify_size_t_vector(recv_counts);
+  std::vector<int> recv_displs_ = intify_size_t_vector(recv_displs);
+  MPI_Alltoallv(buf_or_inplace(sendbuf),
+                send_counts_.data(), send_displs_.data(), TypeMap<T>(),
+                recvbuf,
+                recv_counts_.data(), recv_displs_.data(), TypeMap<T>(),
+                comm.get_comm());
+}
+
+template <typename T>
+class AlltoallvAlState : public MPIState {
+public:
+  AlltoallvAlState(const T* sendbuf_,
+                   std::vector<size_t> send_counts_,
+                   std::vector<size_t> send_displs_,
+                   T* recvbuf_,
+                   std::vector<size_t> recv_counts_,
+                   std::vector<size_t> recv_displs_,
+                   MPICommunicator& comm_, AlRequest req_) :
+    MPIState(req_),
+    sendbuf(sendbuf_),
+    send_counts(intify_size_t_vector(send_counts_)),
+    send_displs(intify_size_t_vector(send_displs_)),
+    recvbuf(recvbuf_),
+    recv_counts(intify_size_t_vector(recv_counts_)),
+    recv_displs(intify_size_t_vector(recv_displs_)),
+    comm(comm_.get_comm()) {}
+
+  ~AlltoallvAlState() override {}
+
+  std::string get_name() const override { return "MPIAlltoallv"; }
+
+protected:
+  void start_mpi_op() override {
+    MPI_Ialltoallv(buf_or_inplace(sendbuf),
+                   send_counts.data(), send_displs.data(), TypeMap<T>(),
+                   recvbuf,
+                   recv_counts.data(), recv_displs.data(), TypeMap<T>(),
+                   comm, get_mpi_req());
+  }
+
+private:
+  const T* sendbuf;
+  std::vector<int> send_counts;
+  std::vector<int> send_displs;
+  T* recvbuf;
+  std::vector<int> recv_counts;
+  std::vector<int> recv_displs;
+  MPI_Comm comm;
+};
+
+template <typename T>
+void passthrough_nb_alltoallv(const T* sendbuf,
+                              std::vector<size_t> send_counts,
+                              std::vector<size_t> send_displs,
+                              T* recvbuf,
+                              std::vector<size_t> recv_counts,
+                              std::vector<size_t> recv_displs,
+                              MPICommunicator& comm, AlRequest& req) {
+  req = internal::get_free_request();
+  internal::mpi::AlltoallvAlState<T>* state =
+    new internal::mpi::AlltoallvAlState<T>(
+      sendbuf, send_counts, send_displs,
+      recvbuf, recv_counts, recv_displs, comm, req);
+  get_progress_engine()->enqueue(state);
+}
+
+}  // namespace mpi
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/mpi/gatherv.hpp
+++ b/include/aluminum/mpi/gatherv.hpp
@@ -1,0 +1,110 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "progress.hpp"
+#include "mpi/base_state.hpp"
+#include "mpi/communicator.hpp"
+#include "mpi/utils.hpp"
+
+namespace Al {
+namespace internal {
+namespace mpi {
+
+// Data is passed in recvbuf on non-root processes when in-place.
+template <typename T>
+void passthrough_gatherv(const T* sendbuf, T* recvbuf, 
+                         std::vector<size_t> counts,
+                         std::vector<size_t> displs,
+                         int root, MPICommunicator& comm) {
+  std::vector<int> counts_ = intify_size_t_vector(counts);
+  std::vector<int> displs_ = intify_size_t_vector(displs);
+  if (sendbuf == IN_PLACE<T>() && comm.rank() != root) {
+    sendbuf = recvbuf;
+  }
+  MPI_Gatherv(buf_or_inplace(sendbuf), counts[comm.rank()], TypeMap<T>(),
+              recvbuf, counts_.data(), displs_.data(), TypeMap<T>(), root,
+              comm.get_comm());
+}
+
+template <typename T>
+class GathervAlState : public MPIState {
+public:
+  GathervAlState(const T* sendbuf_, T* recvbuf_,
+                 std::vector<size_t> counts_,
+                 std::vector<size_t> displs_,
+                 int root_,
+                 MPICommunicator& comm_, AlRequest req_) :
+    MPIState(req_),
+    sendbuf(sendbuf_), recvbuf(recvbuf_),
+    counts(intify_size_t_vector(counts_)),
+    displs(intify_size_t_vector(displs_)),
+    root(root_),
+    comm(comm_.get_comm()), rank(comm_.rank()) {}
+
+  ~GathervAlState() override {}
+
+  std::string get_name() const override { return "MPIGatherv"; }
+
+protected:
+  void start_mpi_op() override {
+    if (sendbuf == IN_PLACE<T>() && rank != root) {
+      sendbuf = recvbuf;
+    }
+    MPI_Igatherv(buf_or_inplace(sendbuf), counts[rank], TypeMap<T>(),
+                 recvbuf, counts.data(), displs.data(), TypeMap<T>(), root,
+                 comm, get_mpi_req());
+  }
+
+private:
+  const T* sendbuf;
+  T* recvbuf;
+  std::vector<int> counts;
+  std::vector<int> displs;
+  int root;
+  MPI_Comm comm;
+  int rank;
+};
+
+// Data is passed in recvbuf on non-root processes when in-place.
+template <typename T>
+void passthrough_nb_gatherv(const T* sendbuf, T* recvbuf,
+                            std::vector<size_t> counts,
+                            std::vector<size_t> displs,
+                            int root,
+                            MPICommunicator& comm, AlRequest& req) {
+  req = internal::get_free_request();
+  internal::mpi::GathervAlState<T>* state =
+    new internal::mpi::GathervAlState<T>(
+      sendbuf, recvbuf, counts, displs, root, comm, req);
+  get_progress_engine()->enqueue(state);
+}
+
+}  // namespace mpi
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/mpi/reduce_scatter.hpp
+++ b/include/aluminum/mpi/reduce_scatter.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "progress.hpp"
+#include "mpi/base_state.hpp"
 #include "mpi/communicator.hpp"
 #include "mpi/utils.hpp"
 
@@ -44,34 +45,25 @@ void passthrough_reduce_scatter(const T* sendbuf, T* recvbuf, size_t count,
 }
 
 template <typename T>
-class ReduceScatterAlState : public AlState {
+class ReduceScatterAlState : public MPIState {
 public:
   ReduceScatterAlState(const T* sendbuf_, T* recvbuf_, size_t count_,
                        ReductionOperator op_, MPICommunicator& comm_,
                        AlRequest req_) :
-    AlState(req_),
+    MPIState(req_),
     sendbuf(sendbuf_), recvbuf(recvbuf_), count(count_),
     op(ReductionOperator2MPI_Op(op_)),
     comm(comm_.get_comm()) {}
 
   ~ReduceScatterAlState() override {}
 
-  void start() override {
-    AlState::start();
-    MPI_Ireduce_scatter_block(buf_or_inplace(sendbuf), recvbuf, count,
-                              TypeMap<T>(), op, comm, &mpi_req);
-  }
-
-  PEAction step() override {
-    int flag;
-    MPI_Test(&mpi_req, &flag, MPI_STATUS_IGNORE);
-    if (flag) {
-      return PEAction::complete;
-    }
-    return PEAction::cont;
-  }
-
   std::string get_name() const override { return "MPIReduceScatter"; }
+
+protected:
+  void start_mpi_op() override {
+    MPI_Ireduce_scatter_block(buf_or_inplace(sendbuf), recvbuf, count,
+                              TypeMap<T>(), op, comm, get_mpi_req());
+  }
 
 private:
   const T* sendbuf;
@@ -79,7 +71,6 @@ private:
   size_t count;
   MPI_Op op;
   MPI_Comm comm;
-  MPI_Request mpi_req;
 };
 
 template <typename T>

--- a/include/aluminum/mpi/scatter.hpp
+++ b/include/aluminum/mpi/scatter.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "progress.hpp"
+#include "mpi/base_state.hpp"
 #include "mpi/communicator.hpp"
 #include "mpi/utils.hpp"
 
@@ -49,37 +50,28 @@ void passthrough_scatter(const T* sendbuf, T* recvbuf, size_t count, int root,
 }
 
 template <typename T>
-class ScatterAlState : public AlState {
+class ScatterAlState : public MPIState {
 public:
   ScatterAlState(const T* sendbuf_, T* recvbuf_, size_t count_, int root_,
                  MPICommunicator& comm_, AlRequest req_) :
-    AlState(req_),
+    MPIState(req_),
     sendbuf(sendbuf_), recvbuf(recvbuf_), count(count_), root(root_),
     comm(comm_.get_comm()), rank(comm_.rank()) {}
 
   ~ScatterAlState() override {}
 
-  void start() override {
-    AlState::start();
-    if (sendbuf == IN_PLACE<T>() && rank == root) {
+  std::string get_name() const override { return "MPIScatter"; }
+
+protected:
+  void start_mpi_op() override {
+        if (sendbuf == IN_PLACE<T>() && rank == root) {
       sendbuf = recvbuf;
       recvbuf = IN_PLACE<T>();
     }
     MPI_Iscatter(sendbuf, count, TypeMap<T>(),
                  buf_or_inplace(recvbuf), count, TypeMap<T>(),
-                 root, comm, &mpi_req);
+                 root, comm, get_mpi_req());
   }
-
-  PEAction step() override {
-    int flag;
-    MPI_Test(&mpi_req, &flag, MPI_STATUS_IGNORE);
-    if (flag) {
-      return PEAction::complete;
-    }
-    return PEAction::cont;
-  }
-
-  std::string get_name() const override { return "MPIScatter"; }
 
 private:
   const T* sendbuf;
@@ -88,7 +80,6 @@ private:
   int root;
   MPI_Comm comm;
   int rank;
-  MPI_Request mpi_req;
 };
 
 // When in-place, it is recvbuf that uses IN_PLACE.

--- a/include/aluminum/mpi/scatterv.hpp
+++ b/include/aluminum/mpi/scatterv.hpp
@@ -1,0 +1,112 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "progress.hpp"
+#include "mpi/base_state.hpp"
+#include "mpi/communicator.hpp"
+#include "mpi/utils.hpp"
+
+namespace Al {
+namespace internal {
+namespace mpi {
+
+// Data is passed in recvbuf on root processes when in-place.
+template <typename T>
+void passthrough_scatterv(const T* sendbuf, T* recvbuf,
+                          std::vector<size_t> counts,
+                          std::vector<size_t> displs,
+                          int root,
+                          MPICommunicator& comm) {
+  std::vector<int> counts_ = intify_size_t_vector(counts);
+  std::vector<int> displs_ = intify_size_t_vector(displs);
+  if (sendbuf == IN_PLACE<T>() && comm.rank() == root) {
+    sendbuf = recvbuf;
+    recvbuf = IN_PLACE<T>();
+  }
+  MPI_Scatterv(sendbuf, counts_.data(), displs_.data(), TypeMap<T>(),
+               buf_or_inplace(recvbuf), counts[comm.rank()], TypeMap<T>(),
+               root, comm.get_comm());
+}
+
+template <typename T>
+class ScattervAlState : public MPIState {
+public:
+  ScattervAlState(const T* sendbuf_, T* recvbuf_,
+                  std::vector<size_t> counts_,
+                  std::vector<size_t> displs_,
+                  int root_,
+                  MPICommunicator& comm_, AlRequest req_) :
+    MPIState(req_),
+    sendbuf(sendbuf_), recvbuf(recvbuf_),
+    counts(intify_size_t_vector(counts_)),
+    displs(intify_size_t_vector(displs_)),
+    root(root_),
+    comm(comm_.get_comm()), rank(comm_.rank()) {}
+
+  ~ScattervAlState() override {}
+
+  std::string get_name() const override { return "MPIScatterv"; }
+
+protected:
+  void start_mpi_op() override {
+    if (sendbuf == IN_PLACE<T>() && rank == root) {
+      sendbuf = recvbuf;
+      recvbuf = IN_PLACE<T>();
+    }
+    MPI_Iscatterv(sendbuf, counts.data(), displs.data(), TypeMap<T>(),
+                  buf_or_inplace(recvbuf), counts[rank], TypeMap<T>(),
+                  root, comm, get_mpi_req());
+  }
+
+private:
+  const T* sendbuf;
+  T* recvbuf;
+  std::vector<int> counts;
+  std::vector<int> displs;
+  int root;
+  MPI_Comm comm;
+  int rank;
+};
+
+// When in-place, it is recvbuf that uses IN_PLACE.
+template <typename T>
+void passthrough_nb_scatterv(const T* sendbuf, T* recvbuf,
+                             std::vector<size_t> counts,
+                             std::vector<size_t> displs,
+                             int root, MPICommunicator& comm, AlRequest& req) {
+  req = internal::get_free_request();
+  internal::mpi::ScattervAlState<T>* state =
+    new internal::mpi::ScattervAlState<T>(
+      sendbuf, recvbuf, counts, displs, root, comm, req);
+  get_progress_engine()->enqueue(state);
+}
+
+}  // namespace mpi
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/mpi/utils.hpp
+++ b/include/aluminum/mpi/utils.hpp
@@ -62,6 +62,16 @@ const void* buf_or_inplace(const T* buf) {
   return buf == IN_PLACE<T>() ? MPI_IN_PLACE : buf;
 }
 
+/**
+ * Convert a vector of size_ts to a vector of ints.
+ *
+ * This is used since MPI requires arrays of ints, which are a different size
+ * than size_t.
+ */
+inline std::vector<int> intify_size_t_vector(const std::vector<size_t> v) {
+  return std::vector<int>(v.begin(), v.end());
+}
+
 /** True if count elements can be sent by MPI. */
 inline bool check_count_fits_mpi(size_t count) {
   return count <= static_cast<size_t>(std::numeric_limits<int>::max());

--- a/include/aluminum/trace.hpp
+++ b/include/aluminum/trace.hpp
@@ -39,6 +39,22 @@ namespace internal {
 class AlState;
 namespace trace {
 
+#ifdef AL_TRACE
+// Need to be able to print vectors.
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
+  os << "[";
+  if (!v.empty()) {
+    for (size_t i = 0; i < v.size() - 1; ++i) {
+      os << v[i] << ", ";
+    }
+    os << v[v.size() - 1];
+  }
+  os << "]";
+  return os;
+}
+#endif
+
 /**
  * Save entry to the trace log.
  * progress is whether this comes from the progress engine, which is recorded

--- a/include/aluminum/utils.hpp
+++ b/include/aluminum/utils.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <chrono>
+#include <vector>
 
 namespace Al {
 
@@ -36,6 +37,19 @@ inline double get_time() {
   using namespace std::chrono;                                                  
   return duration_cast<duration<double>>(                                       
     steady_clock::now().time_since_epoch()).count();                            
+}
+
+/**
+ * Compute an exclusive prefix sum.
+ *
+ * This is mostly meant to help with vector collectives.
+ */
+inline std::vector<size_t> excl_prefix_sum(const std::vector<size_t>& v) {
+  std::vector<size_t> r = std::vector<size_t>(v.size(), size_t{0});
+  for (size_t i = 1; i < v.size(); ++i) {
+    r[i] = v[i-1] + r[i-1];
+  }
+  return r;
 }
 
 }  // namespace Al

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,10 +42,14 @@ set_source_path(TEST_SRCS
   test_reduce.cpp
   test_reduce_scatter.cpp
   test_allgather.cpp
+  test_allgatherv.cpp
   test_alltoall.cpp
+  test_alltoallv.cpp
   test_bcast.cpp
   test_gather.cpp
+  test_gatherv.cpp
   test_scatter.cpp
+  test_scatterv.cpp
   test_pt2pt.cpp
   test_exchange.cpp
   test_transfer_to_one.cpp

--- a/test/test_allgatherv.cpp
+++ b/test/test_allgatherv.cpp
@@ -1,0 +1,186 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include "Al.hpp"
+#include "test_utils.hpp"
+#ifdef AL_HAS_NCCL
+#include "test_utils_nccl_cuda.hpp"
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+#include "test_utils_ht.hpp"
+#endif
+
+#include <stdlib.h>
+#include <math.h>
+#include <string>
+
+// Size is the per-rank send size.
+size_t start_size = 1;
+size_t max_size = 1<<30;
+
+// For simplicity, the allgatherv is equivalent to an allgather here.
+
+/**
+ * Test allgatherv algo on input, check with expected.
+ */
+template <typename Backend>
+void test_allgatherv_algo(const typename VectorType<Backend>::type& expected,
+                          const typename VectorType<Backend>::type& expected_inplace,
+                          typename VectorType<Backend>::type input,
+                          typename VectorType<Backend>::type input_inplace,
+                          typename Backend::comm_type& comm,
+                          typename Backend::allgather_algo_type algo) {
+  auto recv = get_vector<Backend>(input.size() * comm.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(), input.size());
+  std::vector<size_t> displs = Al::excl_prefix_sum(counts);
+  // Test regular allgatherv.
+  Al::Allgatherv<Backend>(input.data(), recv.data(), counts, displs,
+                          comm, algo);
+  if (!check_vector(expected, recv)) {
+    std::cout << comm.rank() << ": regular allgatherv does not match" <<
+        std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place allgather.
+  Al::Allgatherv<Backend>(input_inplace.data(), counts, displs,
+                         comm, algo);
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (!check_vector(expected_inplace, input_inplace)) {
+    std::cout << comm.rank() << ": in-place allgatherv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+/**
+ * Test non-blocking allgatherv algo on input, check with expected.
+ */
+template <typename Backend>
+void test_nb_allgatherv_algo(const typename VectorType<Backend>::type& expected,
+                             const typename VectorType<Backend>::type& expected_inplace,
+                             typename VectorType<Backend>::type input,
+                             typename VectorType<Backend>::type input_inplace,
+                             typename Backend::comm_type& comm,
+                             typename Backend::allgather_algo_type algo) {
+  typename Backend::req_type req = get_request<Backend>();
+  auto recv = get_vector<Backend>(input.size() * comm.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(), input.size());
+  std::vector<size_t> displs = Al::excl_prefix_sum(counts);
+  // Test regular allgatherv.
+  Al::NonblockingAllgatherv<Backend>(input.data(), recv.data(),
+                                     counts, displs, comm, req, algo);
+  Al::Wait<Backend>(req);
+  if (!check_vector(expected, recv)) {
+    std::cout << comm.rank() << ": regular allgatherv does not match" <<
+      std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place allgatherv.
+  Al::NonblockingAllgatherv<Backend>(input_inplace.data(),
+                                     counts, displs,
+                                     comm, req, algo);
+  Al::Wait<Backend>(req);
+  if (!check_vector(expected_inplace, input_inplace)) {
+    std::cout << comm.rank() << ": in-place allgatherv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+template <typename Backend>
+void test_correctness() {
+  auto algos = get_allgatherv_algorithms<Backend>();
+  auto nb_algos = get_nb_allgatherv_algorithms<Backend>();
+  typename Backend::comm_type comm = get_comm_with_stream<Backend>(MPI_COMM_WORLD);
+  // Compute sizes to test.
+  std::vector<size_t> sizes = get_sizes(start_size, max_size, true);
+  for (const auto& size : sizes) {
+    if (comm.rank() == 0) {
+      std::cout << "Testing size " << human_readable_size(size) << std::endl;
+    }
+    // Compute true value.
+    size_t global_size = size * comm.size();
+    typename VectorType<Backend>::type &&data = gen_data<Backend>(size);
+    auto expected = get_vector<Backend>(global_size);
+    get_expected_allgather_result(data, expected);
+    typename VectorType<Backend>::type &&data_inplace = gen_data<Backend>(global_size);
+    auto expected_inplace(data_inplace);
+    get_expected_allgather_inplace_result(expected_inplace);
+    // Test algorithms.
+    for (auto&& algo : algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        std::cout << " Algo: " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_allgatherv_algo<Backend>(expected, expected_inplace,
+                                    data, data_inplace, comm, algo);
+    }
+    for (auto&& algo : nb_algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        std::cout << " Algo: NB " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_nb_allgatherv_algo<Backend>(expected, expected_inplace,
+                                       data, data_inplace, comm, algo);
+    }
+  }
+  free_comm_with_stream<Backend>(comm);
+}
+
+int main(int argc, char** argv) {
+  // Need to set the CUDA device before initializing Aluminum.
+#ifdef AL_HAS_CUDA
+  set_device();
+#endif
+  Al::Initialize(argc, argv);
+
+  std::string backend = "MPI";
+  parse_args(argc, argv, backend, start_size, max_size);
+
+  if (backend == "MPI") {
+    test_correctness<Al::MPIBackend>();
+#ifdef AL_HAS_NCCL
+  } else if (backend == "NCCL") {
+    //test_correctness<Al::NCCLBackend>();
+#endif
+#ifdef AL_HAS_MPI_CUDA
+  } else if (backend == "MPI-CUDA") {
+    std::cerr << "Allgatherv not supported on MPI-CUDA backend." << std::endl;
+    std::abort();
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+  } else if (backend == "HT") {
+    //test_correctness<Al::HostTransferBackend>();
+#endif
+  }
+
+  Al::Finalize();
+  return 0;
+}

--- a/test/test_allgatherv.cpp
+++ b/test/test_allgatherv.cpp
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
     test_correctness<Al::MPIBackend>();
 #ifdef AL_HAS_NCCL
   } else if (backend == "NCCL") {
-    //test_correctness<Al::NCCLBackend>();
+    test_correctness<Al::NCCLBackend>();
 #endif
 #ifdef AL_HAS_MPI_CUDA
   } else if (backend == "MPI-CUDA") {

--- a/test/test_alltoallv.cpp
+++ b/test/test_alltoallv.cpp
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
     test_correctness<Al::MPIBackend>();
 #ifdef AL_HAS_NCCL
   } else if (backend == "NCCL") {
-    //test_correctness<Al::NCCLBackend>();
+    test_correctness<Al::NCCLBackend>();
 #endif
 #ifdef AL_HAS_MPI_CUDA
   } else if (backend == "MPI-CUDA") {

--- a/test/test_alltoallv.cpp
+++ b/test/test_alltoallv.cpp
@@ -1,0 +1,178 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include "Al.hpp"
+#include "test_utils.hpp"
+#ifdef AL_HAS_NCCL
+#include "test_utils_nccl_cuda.hpp"
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+#include "test_utils_ht.hpp"
+#endif
+
+#include <stdlib.h>
+#include <math.h>
+#include <string>
+
+// Per-process send/recv size.
+size_t start_size = 1;
+size_t max_size = 1<<30;
+
+// For simplicity, the alltoallv is equivalent to an alltoall here.
+
+/**
+ * Test alltoall algo on input, check with expected.
+ */
+template <typename Backend>
+void test_alltoallv_algo(const typename VectorType<Backend>::type& expected,
+                         typename VectorType<Backend>::type input,
+                         typename Backend::comm_type& comm,
+                         typename Backend::alltoallv_algo_type algo) {
+  auto recv = get_vector<Backend>(input.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(),
+                                                   input.size() / comm.size());
+  std::vector<size_t> displs = Al::excl_prefix_sum(counts);
+  // Test regular alltoallv.
+  Al::Alltoallv<Backend>(input.data(), counts, displs,
+                         recv.data(), counts, displs,
+                         comm, algo);
+  if (!check_vector(expected, recv)) {
+    std::cout << comm.rank() << ": regular alltoallv does not match" <<
+        std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place alltoallv.
+  Al::Alltoallv<Backend>(input.data(), counts, displs, comm, algo);
+  if (!check_vector(expected, input)) {
+    std::cout << comm.rank() << ": in-place alltoallv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+/**
+ * Test non-blocking alltoallv algo on input, check with expected.
+ */
+template <typename Backend>
+void test_nb_alltoallv_algo(const typename VectorType<Backend>::type& expected,
+                            typename VectorType<Backend>::type input,
+                            typename Backend::comm_type& comm,
+                            typename Backend::alltoallv_algo_type algo) {
+  typename Backend::req_type req = get_request<Backend>();
+  auto recv = get_vector<Backend>(input.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(),
+                                                   input.size() / comm.size());
+  std::vector<size_t> displs = Al::excl_prefix_sum(counts);
+  // Test regular alltoallv.
+  Al::NonblockingAlltoallv<Backend>(input.data(), counts, displs,
+                                    recv.data(), counts, displs,
+                                    comm, req, algo);
+  Al::Wait<Backend>(req);
+  if (!check_vector(expected, recv)) {
+    std::cout << comm.rank() << ": regular alltoallv does not match" <<
+      std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place alltoallv.
+  Al::NonblockingAlltoallv<Backend>(input.data(), counts, displs,
+                                    comm, req, algo);
+  Al::Wait<Backend>(req);
+  if (!check_vector(expected, input)) {
+    std::cout << comm.rank() << ": in-place alltoallv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+template <typename Backend>
+void test_correctness() {
+  auto algos = get_alltoallv_algorithms<Backend>();
+  auto nb_algos = get_nb_alltoallv_algorithms<Backend>();
+  typename Backend::comm_type comm = get_comm_with_stream<Backend>(MPI_COMM_WORLD);
+  // Compute sizes to test.
+  std::vector<size_t> sizes = get_sizes(start_size, max_size, true);
+  for (const auto& size : sizes) {
+    if (comm.rank() == 0) {
+      std::cout << "Testing size " << human_readable_size(size) << std::endl;
+    }
+    size_t full_size = size * comm.size();
+    // Compute true value.
+    typename VectorType<Backend>::type &&data = gen_data<Backend>(full_size);
+    auto expected(data);
+    get_expected_alltoall_result(expected);
+    // Test algorithms.
+    for (auto&& algo : algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        std::cout << " Algo: " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_alltoallv_algo<Backend>(expected, data, comm, algo);
+    }
+    for (auto&& algo : nb_algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        std::cout << " Algo: NB " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_nb_alltoallv_algo<Backend>(expected, data, comm, algo);
+    }
+  }
+  free_comm_with_stream<Backend>(comm);
+}
+
+int main(int argc, char** argv) {
+  // Need to set the CUDA device before initializing Aluminum.
+#ifdef AL_HAS_CUDA
+  set_device();
+#endif
+  Al::Initialize(argc, argv);
+
+  std::string backend = "MPI";
+  parse_args(argc, argv, backend, start_size, max_size);
+
+  if (backend == "MPI") {
+    test_correctness<Al::MPIBackend>();
+#ifdef AL_HAS_NCCL
+  } else if (backend == "NCCL") {
+    //test_correctness<Al::NCCLBackend>();
+#endif
+#ifdef AL_HAS_MPI_CUDA
+  } else if (backend == "MPI-CUDA") {
+    std::cerr << "Alltoallv not supported on MPI-CUDA backend." << std::endl;
+    std::abort();
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+  } else if (backend == "HT") {
+    //test_correctness<Al::HostTransferBackend>();
+#endif
+  }
+
+  Al::Finalize();
+  return 0;
+}

--- a/test/test_gatherv.cpp
+++ b/test/test_gatherv.cpp
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
     test_correctness<Al::MPIBackend>();
 #ifdef AL_HAS_NCCL
   } else if (backend == "NCCL") {
-    //test_correctness<Al::NCCLBackend>();
+    test_correctness<Al::NCCLBackend>();
 #endif
 #ifdef AL_HAS_MPI_CUDA
   } else if (backend == "MPI-CUDA") {

--- a/test/test_gatherv.cpp
+++ b/test/test_gatherv.cpp
@@ -1,0 +1,177 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include "Al.hpp"
+#include "test_utils.hpp"
+#ifdef AL_HAS_NCCL
+#include "test_utils_nccl_cuda.hpp"
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+#include "test_utils_ht.hpp"
+#endif
+
+#include <stdlib.h>
+#include <math.h>
+#include <string>
+
+// Per-rank data size.
+size_t start_size = 1;
+size_t max_size = 1<<30;
+
+// For simplicity, the gatherv is equivalent to a gather here.
+
+/**
+ * Test gatherv algo on input, check with expected.
+ */
+template <typename Backend>
+void test_gatherv_algo(const typename VectorType<Backend>::type& expected,
+                       typename VectorType<Backend>::type input,
+                       typename Backend::comm_type& comm,
+                       typename Backend::gatherv_algo_type algo) {
+  auto recv = get_vector<Backend>(input.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(),
+                                                   input.size() / comm.size());
+  std::vector<size_t> displs = Al::excl_prefix_sum(counts);
+  // Test regular gatherv.
+  Al::Gatherv<Backend>(input.data(), recv.data(), counts, displs,
+                       0, comm, algo);
+  if (comm.rank() == 0 && !check_vector(expected, recv)) {
+    std::cout << comm.rank() << ": regular gatherv does not match" <<
+        std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place gatherv.
+  Al::Gatherv<Backend>(input.data(), counts, displs, 0, comm, algo);
+  if (comm.rank() == 0 && !check_vector(expected, input)) {
+    std::cout << comm.rank() << ": in-place gatherv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+/**
+ * Test non-blocking gatherv algo on input, check with expected.
+ */
+template <typename Backend>
+void test_nb_gatherv_algo(const typename VectorType<Backend>::type& expected,
+                          typename VectorType<Backend>::type input,
+                          typename Backend::comm_type& comm,
+                          typename Backend::gather_algo_type algo) {
+  typename Backend::req_type req = get_request<Backend>();
+  auto recv = get_vector<Backend>(input.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(),
+                                                   input.size() / comm.size());
+  std::vector<size_t> displs = Al::excl_prefix_sum(counts);
+  // Test regular gatherv.
+  Al::NonblockingGatherv<Backend>(input.data(), recv.data(),
+                                  counts, displs,
+                                  0, comm, req, algo);
+  Al::Wait<Backend>(req);
+  if (comm.rank() == 0 && !check_vector(expected, recv)) {
+    std::cout << comm.rank() << ": regular gatherv does not match" <<
+      std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place gatherv.
+  Al::NonblockingGatherv<Backend>(input.data(), counts, displs,
+                                  0, comm, req, algo);
+  Al::Wait<Backend>(req);
+  if (comm.rank() == 0 && !check_vector(expected, input)) {
+    std::cout << comm.rank() << ": in-place gatherv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+template <typename Backend>
+void test_correctness() {
+  auto algos = get_gatherv_algorithms<Backend>();
+  auto nb_algos = get_nb_gatherv_algorithms<Backend>();
+  typename Backend::comm_type comm = get_comm_with_stream<Backend>(MPI_COMM_WORLD);
+  // Compute sizes to test.
+  std::vector<size_t> sizes = get_sizes(start_size, max_size, true);
+  for (const auto& size : sizes) {
+    if (comm.rank() == 0) {
+      std::cout << "Testing size " << human_readable_size(size) << std::endl;
+    }
+    // Compute true value.
+    typename VectorType<Backend>::type &&data = gen_data<Backend>(size*comm.size());
+    auto expected(data);
+    get_expected_gather_result(expected);
+    // Test algorithms.
+    for (auto&& algo : algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        // TODO: Update when we have real algorithm sets for each op.
+        std::cout << " Algo: " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_gatherv_algo<Backend>(expected, data, comm, algo);
+    }
+    for (auto&& algo : nb_algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        std::cout << " Algo: NB " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_nb_gatherv_algo<Backend>(expected, data, comm, algo);
+    }
+  }
+  free_comm_with_stream<Backend>(comm);
+}
+
+int main(int argc, char** argv) {
+  // Need to set the CUDA device before initializing Aluminum.
+#ifdef AL_HAS_CUDA
+  set_device();
+#endif
+  Al::Initialize(argc, argv);
+
+  std::string backend = "MPI";
+  parse_args(argc, argv, backend, start_size, max_size);
+
+  if (backend == "MPI") {
+    test_correctness<Al::MPIBackend>();
+#ifdef AL_HAS_NCCL
+  } else if (backend == "NCCL") {
+    //test_correctness<Al::NCCLBackend>();
+#endif
+#ifdef AL_HAS_MPI_CUDA
+  } else if (backend == "MPI-CUDA") {
+    std::cerr << "Gatherv not supported on MPI-CUDA backend." << std::endl;
+    std::abort();
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+  } else if (backend == "HT") {
+    //test_correctness<Al::HostTransferBackend>();
+#endif
+  }
+
+  Al::Finalize();
+  return 0;
+}

--- a/test/test_scatterv.cpp
+++ b/test/test_scatterv.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv) {
     test_correctness<Al::MPIBackend>();
 #ifdef AL_HAS_NCCL
   } else if (backend == "NCCL") {
-    //test_correctness<Al::NCCLBackend>();
+    test_correctness<Al::NCCLBackend>();
 #endif
 #ifdef AL_HAS_MPI_CUDA
   } else if (backend == "MPI-CUDA") {

--- a/test/test_scatterv.cpp
+++ b/test/test_scatterv.cpp
@@ -1,0 +1,179 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include "Al.hpp"
+#include "test_utils.hpp"
+#ifdef AL_HAS_NCCL
+#include "test_utils_nccl_cuda.hpp"
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+#include "test_utils_ht.hpp"
+#endif
+
+#include <stdlib.h>
+#include <math.h>
+#include <string>
+
+// Per-rank size.
+size_t start_size = 1;
+size_t max_size = 1<<30;
+
+// For simplicity, the allgatherv is equivalent to an allgather here.
+
+/**
+ * Test scatterv algo on input, check with expected.
+ */
+template <typename Backend>
+void test_scatterv_algo(const typename VectorType<Backend>::type& expected,
+                        typename VectorType<Backend>::type input,
+                        typename Backend::comm_type& comm,
+                        typename Backend::scatterv_algo_type algo) {
+  auto recv = get_vector<Backend>(input.size() / comm.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(),
+                                                   input.size() / comm.size());
+  std::vector<size_t> displs = Al::excl_prefix_sum(counts);
+  // Test regular scatterv.
+  Al::Scatterv<Backend>(input.data(), recv.data(),
+                        counts, displs,
+                        0, comm, algo);
+  if (!check_vector(expected, recv, 0, input.size() / comm.size())) {
+    std::cout << comm.rank() << ": regular scatterv does not match" <<
+        std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place scatterv.
+  Al::Scatterv<Backend>(input.data(), counts, displs,
+                        0, comm, algo);
+  if (!check_vector(expected, input, 0, input.size() / comm.size())) {
+    std::cout << comm.rank() << ": in-place scatterv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+/**
+ * Test non-blocking scatterv algo on input, check with expected.
+ */
+template <typename Backend>
+void test_nb_scatterv_algo(const typename VectorType<Backend>::type& expected,
+                           typename VectorType<Backend>::type input,
+                           typename Backend::comm_type& comm,
+                           typename Backend::scatterv_algo_type algo) {
+  typename Backend::req_type req = get_request<Backend>();
+  auto recv = get_vector<Backend>(input.size() / comm.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(),
+                                                   input.size() / comm.size());
+  std::vector<size_t> displs = Al::excl_prefix_sum(counts);
+  // Test regular scatterv.
+  Al::NonblockingScatterv<Backend>(input.data(), recv.data(),
+                                   counts, displs,
+                                   0, comm, req, algo);
+  Al::Wait<Backend>(req);
+  if (!check_vector(expected, recv, 0, input.size() / comm.size())) {
+    std::cout << comm.rank() << ": regular scatterv does not match" <<
+      std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place scatterv.
+  Al::NonblockingScatterv<Backend>(input.data(), counts, displs,
+                                   0, comm, req, algo);
+  Al::Wait<Backend>(req);
+  if (!check_vector(expected, input, 0, input.size() / comm.size())) {
+    std::cout << comm.rank() << ": in-place scatterv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+template <typename Backend>
+void test_correctness() {
+  auto algos = get_scatterv_algorithms<Backend>();
+  auto nb_algos = get_nb_scatterv_algorithms<Backend>();
+  typename Backend::comm_type comm = get_comm_with_stream<Backend>(MPI_COMM_WORLD);
+  // Compute sizes to test.
+  std::vector<size_t> sizes = get_sizes(start_size, max_size, true);
+  for (const auto& size : sizes) {
+    if (comm.rank() == 0) {
+      std::cout << "Testing size " << human_readable_size(size) << std::endl;
+    }
+    // Compute true value.
+    typename VectorType<Backend>::type &&data = gen_data<Backend>(size*comm.size());
+    auto expected(data);
+    get_expected_scatter_result(expected);
+    // Test algorithms.
+    for (auto&& algo : algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        // TODO: Update when we have real algorithm sets for each op.
+        std::cout << " Algo: " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_scatterv_algo<Backend>(expected, data, comm, algo);
+    }
+    for (auto&& algo : nb_algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        std::cout << " Algo: NB " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_nb_scatterv_algo<Backend>(expected, data, comm, algo);
+    }
+  }
+  free_comm_with_stream<Backend>(comm);
+}
+
+int main(int argc, char** argv) {
+  // Need to set the CUDA device before initializing Aluminum.
+#ifdef AL_HAS_CUDA
+  set_device();
+#endif
+  Al::Initialize(argc, argv);
+
+  std::string backend = "MPI";
+  parse_args(argc, argv, backend, start_size, max_size);
+
+  if (backend == "MPI") {
+    test_correctness<Al::MPIBackend>();
+#ifdef AL_HAS_NCCL
+  } else if (backend == "NCCL") {
+    //test_correctness<Al::NCCLBackend>();
+#endif
+#ifdef AL_HAS_MPI_CUDA
+  } else if (backend == "MPI-CUDA") {
+    std::cerr << "Scatterv not supported on MPI-CUDA backend." << std::endl;
+    std::abort();
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+  } else if (backend == "HT") {
+    //test_correctness<Al::HostTransferBackend>();
+#endif
+  }
+
+  Al::Finalize();
+  return 0;
+}

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -206,6 +206,13 @@ std::vector<typename Backend::allgather_algo_type> get_allgather_algorithms() {
 }
 
 template <typename Backend>
+std::vector<typename Backend::allgatherv_algo_type> get_allgatherv_algorithms() {
+  std::vector<typename Backend::allgatherv_algo_type> algos = {
+    Backend::allgatherv_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
 std::vector<typename Backend::bcast_algo_type> get_bcast_algorithms() {
   std::vector<typename Backend::bcast_algo_type> algos = {
     Backend::bcast_algo_type::automatic};
@@ -220,6 +227,13 @@ std::vector<typename Backend::alltoall_algo_type> get_alltoall_algorithms() {
 }
 
 template <typename Backend>
+std::vector<typename Backend::alltoallv_algo_type> get_alltoallv_algorithms() {
+  std::vector<typename Backend::alltoallv_algo_type> algos = {
+    Backend::alltoallv_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
 std::vector<typename Backend::gather_algo_type> get_gather_algorithms() {
   std::vector<typename Backend::gather_algo_type> algos = {
     Backend::gather_algo_type::automatic};
@@ -230,6 +244,20 @@ template <typename Backend>
 std::vector<typename Backend::scatter_algo_type> get_scatter_algorithms() {
   std::vector<typename Backend::scatter_algo_type> algos = {
     Backend::scatter_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
+std::vector<typename Backend::gatherv_algo_type> get_gatherv_algorithms() {
+  std::vector<typename Backend::gatherv_algo_type> algos = {
+    Backend::gatherv_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
+std::vector<typename Backend::scatterv_algo_type> get_scatterv_algorithms() {
+  std::vector<typename Backend::scatterv_algo_type> algos = {
+    Backend::scatterv_algo_type::automatic};
   return algos;
 }
 
@@ -276,6 +304,13 @@ std::vector<typename Backend::allgather_algo_type> get_nb_allgather_algorithms()
 }
 
 template <typename Backend>
+std::vector<typename Backend::allgatherv_algo_type> get_nb_allgatherv_algorithms() {
+  std::vector<typename Backend::allgatherv_algo_type> algos = {
+    Backend::allgatherv_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
 std::vector<typename Backend::bcast_algo_type> get_nb_bcast_algorithms() {
   std::vector<typename Backend::bcast_algo_type> algos = {
     Backend::bcast_algo_type::automatic};
@@ -290,6 +325,13 @@ std::vector<typename Backend::alltoall_algo_type> get_nb_alltoall_algorithms() {
 }
 
 template <typename Backend>
+std::vector<typename Backend::alltoallv_algo_type> get_nb_alltoallv_algorithms() {
+  std::vector<typename Backend::alltoallv_algo_type> algos = {
+    Backend::alltoallv_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
 std::vector<typename Backend::gather_algo_type> get_nb_gather_algorithms() {
   std::vector<typename Backend::gather_algo_type> algos = {
     Backend::gather_algo_type::automatic};
@@ -300,6 +342,20 @@ template <typename Backend>
 std::vector<typename Backend::scatter_algo_type> get_nb_scatter_algorithms() {
   std::vector<typename Backend::scatter_algo_type> algos = {
     Backend::scatter_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
+std::vector<typename Backend::gatherv_algo_type> get_nb_gatherv_algorithms() {
+  std::vector<typename Backend::gatherv_algo_type> algos = {
+    Backend::gatherv_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
+std::vector<typename Backend::scatterv_algo_type> get_nb_scatterv_algorithms() {
+  std::vector<typename Backend::scatterv_algo_type> algos = {
+    Backend::scatterv_algo_type::automatic};
   return algos;
 }
  


### PR DESCRIPTION
This adds support to the Aluminum API for `Allgatherv`, `Alltoallv`, `Scatterv`, and `Gatherv`. It also adds implementations of these ops to the MPI and NCCL backends. Host-transfer support will be a separate PR later.

One note on an API difference: The `Allgatherv`, `Scatterv`, and `Gatherv` calls all expect a single vector of counts/displacements, instead of a single count for the send and a list of counts/displacements for the receive. I think this simplifies the API, but it does require the vector be the right length *on every process*, and the local count be in the right location. When the other counts are not meaningful on a rank, they are not read.

I added tests for these operations, but they're quite simple right now: They essentially replicate the non-vector versions of the calls.

I added a utility function, `Al::excl_prefix_sum` to compute an exclusive prefix sum. This is helpful when the vectors being communicated are contiguous, as it can be used to compute the displacements array from the counts array.

Some other changes:
* I reorganized the implementations of the non-blocking MPI ops to save on implementation time (they all inherit from the `MPIState` class now), except for the Allreduce implementations.
* The NCCL in-place Alltoall calls now use the in-place flag explicitly instead of just passing the same buffer.