### PR TITLE
Handle NCCL group sizes

### DIFF
--- a/include/aluminum/nccl_impl.hpp
+++ b/include/aluminum/nccl_impl.hpp
@@ -213,7 +213,6 @@ void safe_nccl_group(size_t start, size_t limit,
     // since we need a new NCCL group anyway.
     AL_CHECK_NCCL(ncclGroupEnd());
     AL_CHECK_NCCL(ncclGroupStart());
-    closed = true;
   } else {
     cur_nccl_calls += num_per_pre;
   }


### PR DESCRIPTION
Depends on #73. Closes #75.

This adds a helper, `safe_nccl_group`, that will automatically manage NCCL group sizes. NCCL collectives have been updated to use it.

The one rough spot is in rooted collectives, we have the root send and receive to itself. To ensure progress, the send and receive need to be in the same group. I've therefore put them both in the "epilogue" function used by these collectives.

To be conservative, I've set a limit of 1024 operations per group.