### PR TITLE
Vector reduce-scatter

### DIFF
--- a/include/aluminum/Al.hpp
+++ b/include/aluminum/Al.hpp
@@ -335,6 +335,85 @@ void NonblockingReduce_scatter(
 }
 
 /**
+ * @brief Perform a vector reduce-scatter.
+ *
+ * This is analogous to "MPI_Reduce_scatter".
+ *
+ * @param sendbuf Input data.
+ * @param recvbuf Output data.
+ * @param counts Amount of data each rank should receive.
+ * @param op The reduction operation to perform.
+ * @param comm The communicator to reduce/scatter over.
+ * @param algo Request a particular vector reduce-scatter algorithm.
+ */
+template <typename Backend, typename T>
+void Reduce_scatterv(
+  const T* sendbuf, T* recvbuf, std::vector<size_t> counts,
+  ReductionOperator op, typename Backend::comm_type& comm,
+  typename Backend::reduce_scatterv_algo_type algo =
+  Backend::reduce_scatterv_algo_type::automatic) {
+  internal::trace::record_op<Backend, T>(
+    "reduce_scatterv", comm, sendbuf, recvbuf, counts);
+  Backend::template Reduce_scatterv<T>(sendbuf, recvbuf, counts,
+                                       op, comm, algo);
+}
+
+/**
+ * @brief Perform an in-place vector reduce-scatter.
+ *
+ * This is analogous to "MPI_Reduce_scatter".
+ *
+ * @param buf Input and output data.
+ * @param counts Amount of data each rank should receive.
+ * @param op The reduction operation to perform.
+ * @param comm The communicator to reduce/scatter over.
+ * @param algo Request a particular vector reduce-scatter algorithm.
+ */
+template <typename Backend, typename T>
+void Reduce_scatterv(
+  T* buf, std::vector<size_t> counts,
+  ReductionOperator op, typename Backend::comm_type& comm,
+  typename Backend::reduce_scatterv_algo_type algo =
+  Backend::reduce_scatterv_algo_type::automatic) {
+  internal::trace::record_op<Backend, T>(
+    "reduce_scatterv", comm, buf, counts);
+  Backend::template Reduce_scatterv<T>(buf, counts,
+                                       op, comm, algo);
+}
+
+/**
+ * Non-blocking vector reduce-scatter.
+ */
+template <typename Backend, typename T>
+void NonblockingReduce_scatterv(
+  const T* sendbuf, T* recvbuf, std::vector<size_t> counts,
+  ReductionOperator op, typename Backend::comm_type& comm,
+  typename Backend::req_type& req,
+  typename Backend::reduce_scatterv_algo_type algo =
+  Backend::reduce_scatterv_algo_type::automatic) {
+  internal::trace::record_op<Backend, T>(
+    "nonblocking-reduce_scatterv", comm, sendbuf, recvbuf, counts);
+  Backend::template NonblockingReduce_scatterv<T>(
+    sendbuf, recvbuf, counts, op, comm, req, algo);
+}
+
+/**
+ * In-place non-blocking vector reduce-scatter.
+ */
+template <typename Backend, typename T>
+void NonblockingReduce_scatterv(
+  T* buf, std::vector<size_t> counts,
+  ReductionOperator op, typename Backend::comm_type& comm,
+  typename Backend::req_type& req,
+  typename Backend::reduce_scatterv_algo_type algo =
+  Backend::reduce_scatterv_algo_type::automatic) {
+  internal::trace::record_op<Backend, T>(
+    "nonblocking-reduce_scatterv", comm, buf, counts);
+  Backend::template NonblockingReduce_scatterv<T>(
+    buf, counts, op, comm, req, algo);
+}
+
+/**
  * Perform an allgather.
  * @param sendbuf Input data.
  * @param recvbuf Output data; should already be allocated.

--- a/include/aluminum/mpi/CMakeLists.txt
+++ b/include/aluminum/mpi/CMakeLists.txt
@@ -11,6 +11,7 @@ set_source_path(THIS_DIR_HEADERS
   gatherv.hpp
   reduce.hpp
   reduce_scatter.hpp
+  reduce_scatterv.hpp
   scatter.hpp
   scatterv.hpp
   pt2pt.hpp

--- a/include/aluminum/mpi/reduce_scatterv.hpp
+++ b/include/aluminum/mpi/reduce_scatterv.hpp
@@ -1,0 +1,97 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "progress.hpp"
+#include "mpi/base_state.hpp"
+#include "mpi/communicator.hpp"
+#include "mpi/utils.hpp"
+
+namespace Al {
+namespace internal {
+namespace mpi {
+
+template <typename T>
+void passthrough_reduce_scatterv(const T* sendbuf, T* recvbuf,
+                                 std::vector<size_t> counts,
+                                 ReductionOperator op,
+                                 MPICommunicator& comm) {
+  std::vector<int> counts_ = intify_size_t_vector(counts);
+  MPI_Reduce_scatter(buf_or_inplace(sendbuf), recvbuf,
+                     counts_.data(), TypeMap<T>(),
+                     ReductionOperator2MPI_Op(op), comm.get_comm());
+}
+
+template <typename T>
+class ReduceScattervAlState : public MPIState {
+public:
+  ReduceScattervAlState(const T* sendbuf_, T* recvbuf_,
+                        std::vector<size_t> counts_,
+                        ReductionOperator op_, MPICommunicator& comm_,
+                        AlRequest req_) :
+    MPIState(req_),
+    sendbuf(sendbuf_), recvbuf(recvbuf_),
+    counts(intify_size_t_vector(counts_)),
+    op(ReductionOperator2MPI_Op(op_)),
+    comm(comm_.get_comm()) {}
+
+  ~ReduceScattervAlState() override {}
+
+  std::string get_name() const override { return "MPIReduceScatterv"; }
+
+protected:
+  void start_mpi_op() override {
+    MPI_Ireduce_scatter(buf_or_inplace(sendbuf), recvbuf,
+                        counts.data(), TypeMap<T>(), op, comm,
+                        get_mpi_req());
+  }
+
+private:
+  const T* sendbuf;
+  T* recvbuf;
+  std::vector<int> counts;
+  MPI_Op op;
+  MPI_Comm comm;
+};
+
+template <typename T>
+void passthrough_nb_reduce_scatterv(const T* sendbuf, T* recvbuf,
+                                    std::vector<size_t> counts,
+                                    ReductionOperator op,
+                                    MPICommunicator& comm,
+                                    AlRequest& req) {
+  req = internal::get_free_request();
+  internal::mpi::ReduceScattervAlState<T>* state =
+    new internal::mpi::ReduceScattervAlState<T>(
+      sendbuf, recvbuf, counts, op, comm, req);
+  get_progress_engine()->enqueue(state);
+}
+
+}  // namespace mpi
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/utils.hpp
+++ b/include/aluminum/utils.hpp
@@ -33,10 +33,10 @@
 namespace Al {
 
 /** Return time, in seconds (with decimal), since a fixed epoch. */
-inline double get_time() {                                                      
-  using namespace std::chrono;                                                  
-  return duration_cast<duration<double>>(                                       
-    steady_clock::now().time_since_epoch()).count();                            
+inline double get_time() {
+  using namespace std::chrono;
+  return duration_cast<duration<double>>(
+    steady_clock::now().time_since_epoch()).count();
 }
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ set_source_path(TEST_SRCS
   test_allreduce.cpp
   test_reduce.cpp
   test_reduce_scatter.cpp
+  test_reduce_scatterv.cpp
   test_allgather.cpp
   test_allgatherv.cpp
   test_alltoall.cpp

--- a/test/test_reduce_scatterv.cpp
+++ b/test/test_reduce_scatterv.cpp
@@ -1,0 +1,179 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include "Al.hpp"
+#include "test_utils.hpp"
+#ifdef AL_HAS_NCCL
+#include "test_utils_nccl_cuda.hpp"
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+#include "test_utils_ht.hpp"
+#endif
+
+#include <stdlib.h>
+#include <math.h>
+#include <string>
+
+// Size is the per-rank recv size.
+size_t start_size = 1;
+size_t max_size = 1<<30;
+
+/**
+ * Test vector reduce-scatter algo on input, check with expected.
+ */
+template <typename Backend>
+void test_reduce_scatterv_algo(const typename VectorType<Backend>::type& expected,
+                               typename VectorType<Backend>::type input,
+                               typename Backend::comm_type& comm,
+                               typename Backend::reduce_scatterv_algo_type algo) {
+  auto recv = get_vector<Backend>(input.size() / comm.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(),
+                                                   input.size() / comm.size());
+  // Test regular reduce-scatterv.
+  Al::Reduce_scatterv<Backend>(input.data(), recv.data(),
+                               counts,
+                               Al::ReductionOperator::sum, comm, algo);
+  if (!check_vector(expected, recv, 0, input.size() / comm.size())) {
+    std::cout << comm.rank() << ": regular reduce-scatterv does not match" <<
+        std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place reduce-scatterv.
+  Al::Reduce_scatterv<Backend>(input.data(), counts,
+                               Al::ReductionOperator::sum, comm, algo);
+  if (!check_vector(expected, input, 0, input.size() / comm.size())) {
+    std::cout << comm.rank() << ": in-place reduce-scatterv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+/**
+ * Test non-blocking vector reduce-scatter algo on input, check with expected.
+ */
+template <typename Backend>
+void test_nb_reduce_scatterv_algo(const typename VectorType<Backend>::type& expected,
+                                  typename VectorType<Backend>::type input,
+                                  typename Backend::comm_type& comm,
+                                  typename Backend::reduce_scatterv_algo_type algo) {
+  typename Backend::req_type req = get_request<Backend>();
+  auto recv = get_vector<Backend>(input.size() / comm.size());
+  std::vector<size_t> counts = std::vector<size_t>(comm.size(),
+                                                   input.size() / comm.size());
+  // Test regular reduce-scatterv.
+  Al::NonblockingReduce_scatterv<Backend>(input.data(), recv.data(),
+                                          counts,
+                                          Al::ReductionOperator::sum, comm,
+                                          req, algo);
+  Al::Wait<Backend>(req);
+  if (!check_vector(expected, recv, 0, input.size() / comm.size())) {
+    std::cout << comm.rank() << ": regular reduce-scatterv does not match" <<
+      std::endl;
+    std::abort();
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  // Test in-place reduce-scatterv.
+  Al::NonblockingReduce_scatterv<Backend>(input.data(),
+                                          counts,
+                                          Al::ReductionOperator::sum, comm,
+                                          req, algo);
+  Al::Wait<Backend>(req);
+  if (!check_vector(expected, input, 0, input.size() / comm.size())) {
+    std::cout << comm.rank() << ": in-place reduce-scatterv does not match" <<
+      std::endl;
+    std::abort();
+  }
+}
+
+template <typename Backend>
+void test_correctness() {
+  auto algos = get_reduce_scatterv_algorithms<Backend>();
+  auto nb_algos = get_nb_reduce_scatterv_algorithms<Backend>();
+  typename Backend::comm_type comm = get_comm_with_stream<Backend>(MPI_COMM_WORLD);
+  // Compute sizes to test.
+  std::vector<size_t> sizes = get_sizes(start_size, max_size, true);
+  for (const auto& size : sizes) {
+    if (comm.rank() == 0) {
+      std::cout << "Testing size " << human_readable_size(size) << std::endl;
+    }
+    // Compute true value.
+    size_t global_size = size * comm.size();
+    typename VectorType<Backend>::type &&data = gen_data<Backend>(global_size);
+    auto expected(data);
+    get_expected_reduce_scatter_result(expected);
+    // Test algorithms.
+    for (auto&& algo : algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        // TODO: Update when we have real algorithm sets for each op.
+        std::cout << " Algo: " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_reduce_scatterv_algo<Backend>(expected, data, comm, algo);
+    }
+    for (auto&& algo : nb_algos) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (comm.rank() == 0) {
+        std::cout << " Algo: NB " << Al::algorithm_name(algo) << std::endl;
+      }
+      test_nb_reduce_scatterv_algo<Backend>(expected, data, comm, algo);
+    }
+  }
+  free_comm_with_stream<Backend>(comm);
+}
+
+int main(int argc, char** argv) {
+  // Need to set the CUDA device before initializing Aluminum.
+#ifdef AL_HAS_CUDA
+  set_device();
+#endif
+  Al::Initialize(argc, argv);
+
+  std::string backend = "MPI";
+  parse_args(argc, argv, backend, start_size, max_size);
+
+  if (backend == "MPI") {
+    //test_correctness<Al::MPIBackend>();
+#ifdef AL_HAS_NCCL
+  } else if (backend == "NCCL") {
+    test_correctness<Al::NCCLBackend>();
+#endif
+#ifdef AL_HAS_MPI_CUDA
+  } else if (backend == "MPI-CUDA") {
+    std::cerr << "Reduce-scatterv not supported on MPI-CUDA backend." << std::endl;
+    std::abort();
+#endif
+#ifdef AL_HAS_HOST_TRANSFER
+  } else if (backend == "HT") {
+    //test_correctness<Al::HostTransferBackend>();
+#endif
+  }
+
+  Al::Finalize();
+  return 0;
+}

--- a/test/test_reduce_scatterv.cpp
+++ b/test/test_reduce_scatterv.cpp
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
   parse_args(argc, argv, backend, start_size, max_size);
 
   if (backend == "MPI") {
-    //test_correctness<Al::MPIBackend>();
+    test_correctness<Al::MPIBackend>();
 #ifdef AL_HAS_NCCL
   } else if (backend == "NCCL") {
     test_correctness<Al::NCCLBackend>();

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -199,6 +199,13 @@ std::vector<typename Backend::reduce_scatter_algo_type> get_reduce_scatter_algor
 }
 
 template <typename Backend>
+std::vector<typename Backend::reduce_scatterv_algo_type> get_reduce_scatterv_algorithms() {
+  std::vector<typename Backend::reduce_scatterv_algo_type> algos = {
+    Backend::reduce_scatterv_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
 std::vector<typename Backend::allgather_algo_type> get_allgather_algorithms() {
   std::vector<typename Backend::allgather_algo_type> algos = {
     Backend::allgather_algo_type::automatic};
@@ -293,6 +300,13 @@ template <typename Backend>
 std::vector<typename Backend::reduce_scatter_algo_type> get_nb_reduce_scatter_algorithms() {
   std::vector<typename Backend::reduce_scatter_algo_type> algos = {
     Backend::reduce_scatter_algo_type::automatic};
+  return algos;
+}
+
+template <typename Backend>
+std::vector<typename Backend::reduce_scatterv_algo_type> get_nb_reduce_scatterv_algorithms() {
+  std::vector<typename Backend::reduce_scatterv_algo_type> algos = {
+    Backend::reduce_scatterv_algo_type::automatic};
   return algos;
 }
 


### PR DESCRIPTION
Support vector reduce-scatters in the NCCL and MPI backends. Host-transfer backend will come later (as with the other vector collectives).

In MPI, this directly calls `MPI_Reduce_scatter`. In NCCL, this is implemented as a reduce (natively supported in NCCL) followed by a scatterv (our implementation).