### PR TITLE
Add CUB memory pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ if (ALUMINUM_ENABLE_ROCM)
   include(HipBuildSystem)
 
   # Provides hip_add_executable
-  set(CMAKE_MODULE_PATH "/opt/rocm-3.6.0/hip/cmake" ${CMAKE_MODULE_PATH})
+  set(CMAKE_MODULE_PATH "/opt/rocm-3.8.0/hip/cmake" ${CMAKE_MODULE_PATH})
 
   # hip-runtime library
   find_package(HIP REQUIRED)
@@ -286,6 +286,13 @@ if (ALUMINUM_ENABLE_ROCM)
     message(STATUS "Found RCCL: ${rccl_DIR}")
     set(AL_HAS_NCCL TRUE)
   endif ()
+
+  # Find CUB
+  set(CMAKE_PREFIX_PATH "/opt/rocm/hip" ${CMAKE_PREFIX_PATH})
+  set(HIP_FOUND FALSE)
+  find_package(HIP CONFIG REQUIRED)
+  find_package(rocPRIM REQUIRED)
+  find_package(hipCUB REQUIRED)
 
   # Just in case any of the previous commands turned this on.
   set(CMAKE_CXX_EXTENSIONS FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ if (ALUMINUM_ENABLE_CUDA)
   if (CUDA_FOUND)
     enable_language(CUDA)
     set(AL_HAS_CUDA TRUE)
+
     if (ALUMINUM_ENABLE_MPI_CUDA)
       set(AL_HAS_CUDA TRUE)
       set(AL_HAS_MPI_CUDA TRUE)
@@ -225,6 +226,10 @@ if (ALUMINUM_ENABLE_CUDA)
       find_package(NVTX REQUIRED)
       set(AL_HAS_NVPROF ON)
     endif ()
+
+    find_package(CUB REQUIRED)
+    set_property(TARGET cuda::cuda APPEND
+        PROPERTY INTERFACE_LINK_LIBRARIES cuda::CUB)
   else ()
     message(WARNING "CUDA support requested but not found. Disabling.")
     set(ALUMINUM_ENABLE_CUDA OFF)

--- a/cmake/FindCUB.cmake
+++ b/cmake/FindCUB.cmake
@@ -1,0 +1,57 @@
+#[=============[.rst
+FindCUB
+==========
+
+Finds the CUB library.
+
+The following variables will be defined::
+
+  CUB_FOUND          - True if the system has the CUB library.
+  CUB_INCLUDE_DIRS   - The include directory needed for CUB.
+
+The following cache variable will be set and marked as "advanced"::
+
+  CUB_INCLUDE_DIR - The include directory needed for CUB.
+
+In addition, the :prop_tgt:`IMPORTED` target ``cuda::CUB`` will
+be created.
+
+#]=============]
+
+
+find_path(CUB_INCLUDE_PATH cub/cub.cuh
+  HINTS ${CUB_DIR} $ENV{CUB_DIR}
+  ${CUDA_TOOLKIT_ROOT_DIR} ${CUDA_SDK_ROOT_DIR}
+  PATH_SUFFIXES include
+  NO_DEFAULT_PATH
+  DOC "The CUB header directory."
+  )
+find_path(CUB_INCLUDE_PATH cub/cub.cuh)
+
+set(CUB_INCLUDE_DIRS "${CUB_INCLUDE_PATH}")
+
+# Standard handling of the package arguments
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CUB
+  DEFAULT_MSG CUB_INCLUDE_PATH)
+
+# Setup the imported target
+if (NOT TARGET cuda::CUB)
+  add_library(cuda::CUB INTERFACE IMPORTED)
+endif (NOT TARGET cuda::CUB)
+
+# Set the include directories for the target
+if (CUB_INCLUDE_PATH)
+  set_property(TARGET cuda::CUB
+    PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CUB_INCLUDE_PATH})
+endif ()
+
+#
+# Cleanup
+#
+
+# Set the include directories
+mark_as_advanced(FORCE CUB_INCLUDE_PATH)
+
+# Set the libraries
+set(CUB_LIBRARIES cuda::CUB)

--- a/include/aluminum/mempool.hpp
+++ b/include/aluminum/mempool.hpp
@@ -33,6 +33,7 @@
 #include <utility>
 #ifdef AL_HAS_CUDA
 #include "cuda.hpp"
+#include <cub/util_allocator.cuh>
 #endif
 
 namespace Al {
@@ -177,6 +178,32 @@ void release_pinned_memory(T* mem) {
       return;
     }
   }
+}
+
+/** Get the CUB memory pool. */
+inline cub::CachingDeviceAllocator& get_gpu_mempool() {
+  static std::unique_ptr<cub::CachingDeviceAllocator> cub_pool;
+  if (!cub_pool) {
+    cub_pool.reset(new cub::CachingDeviceAllocator(2U));
+  }
+  return *cub_pool;
+}
+
+/** Get GPU memory of type T. */
+template <typename T>
+T* get_gpu_memory(size_t count, cudaStream_t stream = 0) {
+  auto& pool = get_gpu_mempool();
+  T* mem = nullptr;
+  AL_CHECK_CUDA(pool.DeviceAllocate(reinterpret_cast<void**>(&mem),
+                                    sizeof(T)*count, stream));
+  return mem;
+}
+
+/** Release memory that you got with get_gpu_memory. */
+template <typename T>
+void release_gpu_memory(T* mem) {
+  auto& pool = get_gpu_mempool();
+  AL_CHECK_CUDA(pool.DeviceFree(mem));
 }
 
 #endif  // AL_HAS_CUDA

--- a/include/aluminum/mempool.hpp
+++ b/include/aluminum/mempool.hpp
@@ -31,7 +31,10 @@
 #include <vector>
 #include <unordered_map>
 #include <utility>
-#ifdef AL_HAS_CUDA
+#if defined AL_HAS_ROCM
+#include "cuda.hpp"
+#include <hipcub/hipcub.hpp>
+#elif defined AL_HAS_CUDA
 #include "cuda.hpp"
 #include <cub/util_allocator.cuh>
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,9 @@ target_include_directories(Al PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/aluminum>)
 target_link_libraries(Al PUBLIC
   MPI::MPI_CXX HWLOC::hwloc
-  $<TARGET_NAME_IF_EXISTS:roc::rccl>)
+  $<TARGET_NAME_IF_EXISTS:roc::rccl>
+  $<TARGET_NAME_IF_EXISTS:hip::rocprim_hip>
+  $<TARGET_NAME_IF_EXISTS:hip::hipcub>)
 
 target_compile_features(Al PUBLIC cxx_std_11)
 


### PR DESCRIPTION
Closes #77.

Adds CUB memory pool. Updates NCCL backend to no longer `cudaMalloc` GPU memory.

I have not tested HIP support, probably this will require a bit of work.