### PR TITLE
Improve progress engine binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,14 @@ if (ALUMINUM_ENABLE_ROCM)
   find_package(rocPRIM REQUIRED)
   find_package(hipCUB REQUIRED)
 
+  # (trb 11/02/2020): This is not ideal; when things stabilize, I'll
+  # clean this up. Ideally we'll have a CMake config file for this.
+  find_path(ROCM_SMI_INCLUDE_DIR rocm_smi/rocm_smi.h REQUIRED
+    HINTS /opt/rocm-3.8.0/rocm_smi/include)
+
+  find_library(ROCM_SMI_LIBRARY rocm_smi64 REQUIRED
+    HINTS /opt/rocm-3.8.0/rocm_smi/lib)
+
   # Just in case any of the previous commands turned this on.
   set(CMAKE_CXX_EXTENSIONS FALSE)
 

--- a/include/aluminum/progress.hpp
+++ b/include/aluminum/progress.hpp
@@ -47,6 +47,11 @@ namespace Al {
 // Forward declaration.
 class Communicator;
 
+}  // namespace Al
+
+#include "mpi/communicator.hpp"
+
+namespace Al {
 namespace internal {
 // Forward declaration.
 namespace profiling {
@@ -366,7 +371,7 @@ class ProgressEngine {
    */
   std::unordered_map<AlState*, size_t> blocking_reqs;
   /** World communicator. */
-  Communicator* world_comm;
+  mpi::MPICommunicator* world_comm;
 #ifdef AL_HAS_CUDA
   /** Used to pass the original CUDA device to the progress engine thread. */
   std::atomic<int> cur_device;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,11 @@ target_link_libraries(Al PUBLIC
   $<TARGET_NAME_IF_EXISTS:roc::rccl>
   $<TARGET_NAME_IF_EXISTS:hip::rocprim_hip>
   $<TARGET_NAME_IF_EXISTS:hip::hipcub>)
+if (AL_HAS_ROCM)
+  target_include_directories(Al PRIVATE
+    $<BUILD_INTERFACE:${ROCM_SMI_INCLUDE_DIR}>)
+  target_link_libraries(Al PUBLIC ${ROCM_SMI_LIBRARY})
+endif (AL_HAS_ROCM)
 
 target_compile_features(Al PUBLIC cxx_std_11)
 


### PR DESCRIPTION
Requires #82.

Closes #45. Closes #64.

When using CUDA, this should now automatically detect cores close to the GPU device being used. Otherwise this uses similar behavior as before to identify the NUMA node.

(If you've built Aluminum with CUDA support but for some reason are not wanting to use CUDA, there isn't a good way to identify that, and we don't handle that case.)

This should result in more reliable progress engine binding without needing to mess with the `AL_PROGRESS_CORE` or `AL_PROGRESS_RANKS_PER_NUMA_NODE` environment variables (which no longer do anything).