### PR TITLE
Fix MPI error in host-transfer allreduce

### DIFF
--- a/include/aluminum/ht/allreduce.hpp
+++ b/include/aluminum/ht/allreduce.hpp
@@ -95,7 +95,11 @@ class HostTransferState : public AlState {
       }
     }
     if (!ar_started) {
-      host_ar->setup();
+      if (host_ar->setup()) {
+        // Allreduce finishes immediately.
+        ar_done = true;
+        gpu_wait.signal();
+      }
       ar_started = true;
     }
     if (!ar_done) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,8 @@
-set_source_path(TEST_BASE_HDRS test_utils.hpp op_dispatcher.hpp op_runner_impl.hpp)
+set_source_path(TEST_BASE_HDRS
+  test_utils.hpp
+  op_dispatcher.hpp
+  op_runner_impl.hpp
+  hang_watchdog.hpp)
 if (AL_HAS_CUDA)
   set_source_path(TEST_CUDA_HDRS cuda_vector.hpp)
 endif ()

--- a/test/hang_watchdog.hpp
+++ b/test/hang_watchdog.hpp
@@ -41,7 +41,8 @@
 class HangWatchdog {
 public:
   /** Hang with a timeout in seconds. */
-  HangWatchdog(size_t timeout_ = 60) : timeout(timeout_) {
+  HangWatchdog(size_t timeout_ = 60, bool do_abort_ = true) :
+    timeout(timeout_), do_abort(do_abort_) {
     watchdog = std::thread(&HangWatchdog::run, this);
   }
 
@@ -90,6 +91,7 @@ public:
 
 private:
   size_t timeout;
+  bool do_abort;
   std::thread watchdog;
   std::mutex watchdog_mutex;
   std::condition_variable cv;
@@ -117,7 +119,9 @@ private:
         if (!cv.wait_for(lock, std::chrono::seconds(timeout),
                          [&] { return event_finished; })) {
           std::cerr << "Aborting after hang in " << event_desc << std::endl;
-          std::abort();
+          if (do_abort) {
+            std::abort();
+          }
         }
         event_started = false;
         watching_hang = false;

--- a/test/hang_watchdog.hpp
+++ b/test/hang_watchdog.hpp
@@ -1,0 +1,129 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <iostream>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <cstddef>
+
+
+/**
+ * Prints a warning unless it's told some event has completed within a set time.
+ */
+class HangWatchdog {
+public:
+  /** Hang with a timeout in seconds. */
+  HangWatchdog(size_t timeout_ = 60) : timeout(timeout_) {
+    watchdog = std::thread(&HangWatchdog::run, this);
+  }
+
+  ~HangWatchdog() {
+    {
+      std::unique_lock<std::mutex> lock(watchdog_mutex);
+      stop_flag = true;
+    }
+    cv.notify_one();
+    watchdog.join();
+  }
+
+  /** Start waiting for some event. */
+  void start(std::string desc) {
+    {
+      std::unique_lock<std::mutex> lock(watchdog_mutex);
+      if (event_started) {
+        std::cerr << "Cannot start while event is running" << std::endl;
+      }
+      event_desc = desc;
+      event_started = true;
+    }
+    // Notify watchdog to start watching.
+    cv.notify_one();
+    // Wait until the watchdog starts watching.
+    {
+      std::unique_lock<std::mutex> lock(watchdog_mutex);
+      cv.wait(lock, [&] { return watching_hang; });
+    }
+  }
+
+  /** Indicate the event has completed. */
+  void finish() {
+    {
+      std::unique_lock<std::mutex> lock(watchdog_mutex);
+      event_finished = true;
+    }
+    cv.notify_one();
+    // Wait for the watchdog to finish.
+    {
+      std::unique_lock<std::mutex> lock(watchdog_mutex);
+      cv.wait(lock, [&] { return !watching_hang; });
+      event_finished = false;
+    }
+  }
+
+private:
+  size_t timeout;
+  std::thread watchdog;
+  std::mutex watchdog_mutex;
+  std::condition_variable cv;
+  bool stop_flag = false;
+  bool event_started = false;
+  bool watching_hang = false;
+  bool event_finished = false;
+  std::string event_desc;
+
+  void run() {
+    while (true) {
+      // Wait until something starts and acknowledge.
+      {
+        std::unique_lock<std::mutex> lock(watchdog_mutex);
+        cv.wait(lock, [&] { return stop_flag || event_started; });
+        if (stop_flag) {
+          return;
+        }
+        watching_hang = true;
+      }
+      cv.notify_one();
+      // Wait until notified or timeout.
+      {
+        std::unique_lock<std::mutex> lock(watchdog_mutex);
+        if (!cv.wait_for(lock, std::chrono::seconds(timeout),
+                         [&] { return event_finished; })) {
+          std::cerr << "Aborting after hang in " << event_desc << std::endl;
+          std::abort();
+        }
+        event_started = false;
+        watching_hang = false;
+      }
+      // Ack we've seen the completion.
+      cv.notify_one();
+    }
+  }
+};

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -158,7 +158,8 @@ void run_test(cxxopts::ParseResult& parsed_opts) {
   auto sizes = get_sizes_from_opts(parsed_opts);
 
   CommWrapper<Backend> comm_wrapper(MPI_COMM_WORLD);
-  HangWatchdog watchdog;
+  HangWatchdog watchdog(parsed_opts["hang-timeout"].as<size_t>(),
+                        parsed_opts.count("no-abort-on-hang") ? false : true);
 
   bool participates_in_pt2pt = true;
   if (is_pt2pt_op(op)) {
@@ -315,6 +316,8 @@ int main(int argc, char** argv) {
     ("datatype", "Message datatype", cxxopts::value<std::string>()->default_value("float"))
     ("dump-on-error", "Dump vectors on error")
     ("hang-rank", "Hang a specific or all ranks at startup", cxxopts::value<int>()->default_value("-1"))
+    ("hang-timeout", "How long to wait for an operation to complete", cxxopts::value<size_t>()->default_value("60"))
+    ("no-abort-on-hang", "Do not abort if a hang is detected")
     ("help", "Print help");
   auto parsed_opts = options.parse(argc, argv);
 


### PR DESCRIPTION
Depends on #88.

This fixes #89. Note this is somewhat an idiosyncrasy of the custom allreduces in the MPI backend.