### PR TITLE
Output file error checking

### DIFF
--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -136,6 +136,10 @@ public:
 
   void save_results(std::string filename) {
     std::ofstream f(filename);
+    if (f.fail()) {
+      std::cerr << "Error opening " << filename << std::endl;
+      std::abort();
+    }
     write_results(f);
   }
 


### PR DESCRIPTION
We would silently fail to output benchmark information if the output file couldn't be opened. This now throws an error.