### PR TITLE
Fix algorithm handling in tests/benchmarks

### DIFF
--- a/benchmark/benchmark_ops.cpp
+++ b/benchmark/benchmark_ops.cpp
@@ -47,13 +47,15 @@ void run_benchmark(cxxopts::ParseResult& parsed_opts) {
   }
   op_options.root = parsed_opts["root"].as<int>();
   // TODO: Support multiple algorithms -- needs support in OpProfile.
-  auto algorithms = get_algorithms<Backend>(
-    op, parsed_opts["algorithm"].as<std::string>());
-  if (algorithms.size() != 1) {
-    std::cerr << "Can only benchmark one algorithm at a time." << std::endl;
-    std::abort();
+  if (OpSupportsAlgos<Op>::value) {
+    auto algorithms = get_algorithms<Backend>(
+      op, parsed_opts["algorithm"].as<std::string>());
+    if (algorithms.size() != 1) {
+      std::cerr << "Can only benchmark one algorithm at a time." << std::endl;
+      std::abort();
+    }
+    op_options.algos = algorithms[0];
   }
-  op_options.algos = algorithms[0];
 
   auto sizes = get_sizes_from_opts(parsed_opts);
 

--- a/test/op_dispatcher.hpp
+++ b/test/op_dispatcher.hpp
@@ -383,6 +383,17 @@ bool is_reduction_operator_supported(Al::ReductionOperator op) {
   return i->second;
 }
 
+struct supports_algos_functor {
+  template <AlOperation Op>
+  bool operator()() {
+    return OpSupportsAlgos<Op>::value;
+  }
+};
+/** Return true if the operator supports different algorithms. */
+bool op_supports_algos(AlOperation op) {
+  return call_op_functor(op, supports_algos_functor());
+}
+
 /** Contains algorithms for all supported operations. */
 template <typename Backend> struct AlgorithmOptions {};
 

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -154,6 +154,10 @@ void run_test(cxxopts::ParseResult& parsed_opts) {
   op_options.root = parsed_opts["root"].as<int>();
   auto algorithms = get_algorithms<Backend>(
     op, parsed_opts["algorithm"].as<std::string>());
+  // Add a dummy entry if algorithms are not supported.
+  if (!op_supports_algos(op)) {
+    algorithms.emplace_back();
+  }
 
   auto sizes = get_sizes_from_opts(parsed_opts);
 
@@ -200,7 +204,9 @@ void run_test(cxxopts::ParseResult& parsed_opts) {
     }
 
     for (auto&& algo_opt : algorithms) {
-      op_options.algos = algo_opt;
+      if (op_supports_algos(op)) {
+        op_options.algos = algo_opt;
+      }
       OpDispatcher<Backend, T> op_runner(op, op_options);
       // The size is the amount each processor sends to another processor.
       // (Roughly equivalent to the sendcount parameter in MPI.)


### PR DESCRIPTION
Point-to-point operations do not have algorithms, which was not properly accounted for.

Benchmarks would throw an error because there was not exactly one algorithm; tests would silently skip because they iterate over an empty set of algorithms.