### PR TITLE
Barrier API

### DIFF
--- a/include/Al.hpp
+++ b/include/Al.hpp
@@ -514,6 +514,32 @@ void NonblockingAllgatherv(T* buffer,
   Backend::template NonblockingAllgatherv<T>(buffer, counts, displs, comm, req, algo);
 }
 
+/**
+ * Perform a barrier synchronization.
+ *
+ * This will not complete until every process in comm has entered the barrier.
+ *
+ * @param comm The communicator to synchronize over.
+ * @param algo Request a particular barrier algorithm.
+ */
+template <typename Backend>
+void Barrier(typename Backend::comm_type& comm,
+             typename Backend::barrier_algo_type algo =
+             Backend::barrier_algo_type::automatic) {
+  internal::trace::record_op<Backend, void>("barrier", comm);
+  Backend::Barrier(comm, algo);
+}
+
+/** Non-blocking barrier synchronization. */
+template <typename Backend>
+void NonblockingBarrier(typename Backend::comm_type& comm,
+                        typename Backend::req_type& req,
+                        typename Backend::barrier_algo_type algo =
+                        Backend::barrier_algo_type::automatic) {
+  internal::trace::record_op<Backend, void>("nonblocking-barrier", comm);
+  Backend::NonblockingBarrier(comm, req, algo);
+}
+
 // There are no in-place broadcast versions; it is always in-place.
 
 /**

--- a/include/aluminum/mpi/CMakeLists.txt
+++ b/include/aluminum/mpi/CMakeLists.txt
@@ -5,6 +5,7 @@ set_source_path(THIS_DIR_HEADERS
   alltoall.hpp
   alltoallv.hpp
   base_state.hpp
+  barrier.hpp
   bcast.hpp
   communicator.hpp
   gather.hpp

--- a/include/aluminum/mpi/barrier.hpp
+++ b/include/aluminum/mpi/barrier.hpp
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "aluminum/progress.hpp"
+#include "aluminum/mpi/base_state.hpp"
+#include "aluminum/mpi/communicator.hpp"
+#include "aluminum/mpi/utils.hpp"
+
+namespace Al {
+namespace internal {
+namespace mpi {
+
+inline void passthrough_barrier(MPICommunicator& comm) {
+  MPI_Barrier(comm.get_comm());
+}
+
+class BarrierAlState : public MPIState {
+public:
+  BarrierAlState(MPICommunicator& comm_, AlRequest req_)
+      : MPIState(req_), comm(comm_.get_comm()) {}
+  ~BarrierAlState() override {}
+
+  std::string get_name() const override { return "MPIBarrier"; }
+
+protected:
+  void start_mpi_op() override {
+    MPI_Ibarrier(comm, get_mpi_req());
+  }
+
+private:
+  MPI_Comm comm;
+};
+
+inline void passthrough_nb_barrier(MPICommunicator& comm, AlRequest& req) {
+  req = internal::get_free_request();
+  internal::mpi::BarrierAlState* state =
+    new internal::mpi::BarrierAlState(comm, req);
+  get_progress_engine()->enqueue(state);
+}
+
+} // namespace mpi
+} // namespace internal
+} // namespace Al

--- a/include/aluminum/mpi_impl.hpp
+++ b/include/aluminum/mpi_impl.hpp
@@ -42,6 +42,7 @@
 #include "aluminum/mpi/allreduce.hpp"
 #include "aluminum/mpi/alltoall.hpp"
 #include "aluminum/mpi/alltoallv.hpp"
+#include "aluminum/mpi/barrier.hpp"
 #include "aluminum/mpi/bcast.hpp"
 #include "aluminum/mpi/gather.hpp"
 #include "aluminum/mpi/gatherv.hpp"
@@ -122,6 +123,7 @@ class MPIBackend {
   using allgatherv_algo_type = MPICollectiveAlgorithm;
   using alltoall_algo_type = MPICollectiveAlgorithm;
   using alltoallv_algo_type = MPICollectiveAlgorithm;
+  using barrier_algo_type = MPICollectiveAlgorithm;
   using bcast_algo_type = MPICollectiveAlgorithm;
   using gather_algo_type = MPICollectiveAlgorithm;
   using gatherv_algo_type = MPICollectiveAlgorithm;
@@ -475,6 +477,27 @@ class MPIBackend {
     comm_type& comm, req_type& req, alltoallv_algo_type algo) {
     NonblockingAlltoallv(internal::IN_PLACE<T>(), counts, displs,
                          buffer, counts, displs, comm, req, algo);
+  }
+
+  static void Barrier(comm_type& comm, barrier_algo_type algo) {
+    switch (algo) {
+    case MPICollectiveAlgorithm::automatic:
+      internal::mpi::passthrough_barrier(comm);
+      break;
+    default:
+      throw_al_exception("Invalid algorithm");
+    }
+  }
+
+  static void NonblockingBarrier(comm_type& comm, req_type& req,
+                                 barrier_algo_type algo) {
+    switch (algo) {
+    case MPICollectiveAlgorithm::automatic:
+      internal::mpi::passthrough_nb_barrier(comm, req);
+      break;
+    default:
+      throw_al_exception("Invalid algorithm");
+    }
   }
 
   template <typename T>

--- a/test/test_utils_mpi.hpp
+++ b/test/test_utils_mpi.hpp
@@ -38,6 +38,7 @@ template <> struct IsOpSupported<AlOperation::allgatherv, Al::MPIBackend> : std:
 template <> struct IsOpSupported<AlOperation::allreduce, Al::MPIBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::alltoall, Al::MPIBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::alltoallv, Al::MPIBackend> : std::true_type {};
+template <> struct IsOpSupported<AlOperation::barrier, Al::MPIBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::bcast, Al::MPIBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::gather, Al::MPIBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::gatherv, Al::MPIBackend> : std::true_type {};
@@ -89,6 +90,9 @@ template <> struct OpAlgoType<AlOperation::alltoall, Al::MPIBackend> {
 template <> struct OpAlgoType<AlOperation::alltoallv, Al::MPIBackend> {
   using type = Al::MPIBackend::alltoallv_algo_type;
 };
+template <> struct OpAlgoType<AlOperation::barrier, Al::MPIBackend> {
+  using type = Al::MPIBackend::barrier_algo_type;
+};
 template <> struct OpAlgoType<AlOperation::bcast, Al::MPIBackend> {
   using type = Al::MPIBackend::bcast_algo_type;
 };
@@ -139,6 +143,8 @@ struct AlgorithmOptions<Al::MPIBackend> {
     Al::MPIBackend::alltoall_algo_type::automatic;
   typename Al::MPIBackend::alltoallv_algo_type alltoallv_algo =
     Al::MPIBackend::alltoallv_algo_type::automatic;
+  typename Al::MPIBackend::barrier_algo_type barrier_algo =
+    Al::MPIBackend::barrier_algo_type::automatic;
   typename Al::MPIBackend::bcast_algo_type bcast_algo =
     Al::MPIBackend::bcast_algo_type::automatic;
   typename Al::MPIBackend::gather_algo_type gather_algo =

--- a/test/test_utils_nccl.hpp
+++ b/test/test_utils_nccl.hpp
@@ -88,6 +88,7 @@ template <> struct IsOpSupported<AlOperation::allgatherv, Al::NCCLBackend> : std
 template <> struct IsOpSupported<AlOperation::allreduce, Al::NCCLBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::alltoall, Al::NCCLBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::alltoallv, Al::NCCLBackend> : std::true_type {};
+template <> struct IsOpSupported<AlOperation::barrier, Al::NCCLBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::bcast, Al::NCCLBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::gather, Al::NCCLBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::gatherv, Al::NCCLBackend> : std::true_type {};
@@ -140,6 +141,9 @@ template <> struct OpAlgoType<AlOperation::alltoall, Al::NCCLBackend> {
 template <> struct OpAlgoType<AlOperation::alltoallv, Al::NCCLBackend> {
   using type = Al::NCCLBackend::alltoallv_algo_type;
 };
+template <> struct OpAlgoType<AlOperation::barrier, Al::NCCLBackend> {
+  using type = Al::NCCLBackend::barrier_algo_type;
+};
 template <> struct OpAlgoType<AlOperation::bcast, Al::NCCLBackend> {
   using type = Al::NCCLBackend::bcast_algo_type;
 };
@@ -178,6 +182,8 @@ struct AlgorithmOptions<Al::NCCLBackend> {
     Al::NCCLBackend::alltoall_algo_type::automatic;
   typename Al::NCCLBackend::alltoallv_algo_type alltoallv_algo =
     Al::NCCLBackend::alltoallv_algo_type::automatic;
+  typename Al::NCCLBackend::barrier_algo_type barrier_algo =
+    Al::NCCLBackend::barrier_algo_type::automatic;
   typename Al::NCCLBackend::bcast_algo_type bcast_algo =
     Al::NCCLBackend::bcast_algo_type::automatic;
   typename Al::NCCLBackend::gather_algo_type gather_algo =


### PR DESCRIPTION
Depends on #108.

Adds `Barrier` and `NonblockingBarrier` to the public Aluminum API and implementations in the MPI and NCCL backends. The HostTransfer implementation will come later in a separate PR.

Also adds testing/benchmarking support for this, although the test is a bit trivial and doesn't really check for correctness. We probably need a separate test dedicated to barriers if we want that.

The NCCL implementation is quite naive: It does an allreduce on a single byte. It satisfies the requirements, but could be better optimized.