### PR TITLE
Fix multi-threading bug in testing

### DIFF
--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -250,6 +250,7 @@ void run_test(cxxopts::ParseResult& parsed_opts) {
         if (op_options.nonblocking) {
           Al::Wait<Backend>(op_options.req);
         }
+        complete_operations<Backend>(comm_wrapper.comm());
         watchdog.finish();
       }
 

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -109,6 +109,15 @@ struct CommWrapper {
 };
 
 /**
+ * Ensure all Aluminum operations on a communicator have completed.
+ *
+ * For backends that work with compute streams on other devices
+ * (e.g., GPUs), this ensures the operations finish.
+ */
+template <typename Backend>
+void complete_operations(typename Backend::comm_type&) {}
+
+/**
  * Helper to hang for debugging.
  *
  * If non-negative, hangs that rank; if negative, hangs all ranks.

--- a/test/test_utils_ht.hpp
+++ b/test/test_utils_ht.hpp
@@ -62,6 +62,12 @@ CommWrapper<Al::HostTransferBackend>::~CommWrapper() noexcept(false) {
   AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamDestroy(comm_->get_stream()));
 }
 
+template <>
+void complete_operations<Al::HostTransferBackend>(
+  typename Al::HostTransferBackend::comm_type& comm) {
+  AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamSynchronize(comm.get_stream()));
+}
+
 // Operator support.
 template <> struct IsOpSupported<AlOperation::allgather, Al::HostTransferBackend> : std::true_type {};
 //template <> struct IsOpSupported<AlOperation::allgatherv, Al::HostTransferBackend> : std::true_type {};

--- a/test/test_utils_mpi_cuda.hpp
+++ b/test/test_utils_mpi_cuda.hpp
@@ -61,3 +61,9 @@ template <>
 CommWrapper<Al::MPICUDABackend>::~CommWrapper() noexcept(false) {
   AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamDestroy(comm_->get_stream()));
 }
+
+template <>
+void complete_operations<Al::MPICUDABackend>(
+  typename Al::MPICUDABackend::comm_type& comm) {
+  AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamSynchronize(comm.get_stream()));
+}

--- a/test/test_utils_nccl.hpp
+++ b/test/test_utils_nccl.hpp
@@ -81,6 +81,12 @@ CommWrapper<Al::NCCLBackend>::~CommWrapper() noexcept(false) {
   AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamDestroy(comm_->get_stream()));
 }
 
+template <>
+void complete_operations<Al::NCCLBackend>(
+  typename Al::NCCLBackend::comm_type& comm) {
+  AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamSynchronize(comm.get_stream()));
+}
+
 
 // Operator support.
 template <> struct IsOpSupported<AlOperation::allgather, Al::NCCLBackend> : std::true_type {};


### PR DESCRIPTION
Depends on #109. (Because that's the branch I was working on when I found this.)

Our testing infrastructure previously would only wait for host completion of Aluminum communication operations, and would then move on to calling the basic MPI implementation to provide a comparison. This is fine for MPI, since it doesn't have a separate communication thread. However, this breaks for the host-transfer backend, as the Aluminum progress engine could be starting its operation at the same time as the tester starts its comparison call. Because both use the _same_ underlying MPI communicator, this causes Problems™. (The NCCL backend is unaffected, because it doesn't call MPI at all.)

This also means that the hang watchdog may not detect hangs, because we mark the operation as finished before it actually completes.

We now explicitly wait for the communication operation to complete.

Closes #106, which appears to be a spurious issue caused by this.