### PR TITLE
Host-transfer vector collectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The `MPI`, `NCCL`/`RCCL`, and `HostTransfer` backends support the following oper
   * Allreduce
   * Alltoall
   * Vector alltoall
+  * Barrier
   * Broadcast
   * Gather
   * Vector gather
@@ -129,8 +130,6 @@ The `MPI`, `NCCL`/`RCCL`, and `HostTransfer` backends support the following oper
   * Send
   * Recv
   * SendRecv
-
-Note, at the moment, the `HostTransfer` backend does not support vector collectives.
 
 Full API documentation is coming soon...
 

--- a/benchmark/run_benchmarks.py
+++ b/benchmark/run_benchmarks.py
@@ -92,7 +92,7 @@ test_cases = {
         'datatypes': nccl_datatypes
     },
     'ht': {
-        'ops': coll_ops + pt2pt_ops,
+        'ops': coll_ops + vector_coll_ops + pt2pt_ops,
         'datatypes': mpi_datatypes
     },
 }

--- a/include/aluminum/ht/CMakeLists.txt
+++ b/include/aluminum/ht/CMakeLists.txt
@@ -1,15 +1,20 @@
 set_source_path(THIS_DIR_HEADERS
   allgather.hpp
+  allgatherv.hpp
   allreduce.hpp
   alltoall.hpp
+  alltoallv.hpp
   barrier.hpp
   base_state.hpp
   bcast.hpp
   communicator.hpp
   gather.hpp
+  gatherv.hpp
   reduce.hpp
   reduce_scatter.hpp
+  reduce_scatterv.hpp
   scatter.hpp
+  scatterv.hpp
   pt2pt.hpp
   )
 

--- a/include/aluminum/ht/CMakeLists.txt
+++ b/include/aluminum/ht/CMakeLists.txt
@@ -2,6 +2,7 @@ set_source_path(THIS_DIR_HEADERS
   allgather.hpp
   allreduce.hpp
   alltoall.hpp
+  base_state.hpp
   bcast.hpp
   communicator.hpp
   gather.hpp

--- a/include/aluminum/ht/CMakeLists.txt
+++ b/include/aluminum/ht/CMakeLists.txt
@@ -2,6 +2,7 @@ set_source_path(THIS_DIR_HEADERS
   allgather.hpp
   allreduce.hpp
   alltoall.hpp
+  barrier.hpp
   base_state.hpp
   bcast.hpp
   communicator.hpp

--- a/include/aluminum/ht/allgatherv.hpp
+++ b/include/aluminum/ht/allgatherv.hpp
@@ -1,0 +1,95 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "aluminum/cuda.hpp"
+#include "aluminum/ht/communicator.hpp"
+#include "aluminum/ht/base_state.hpp"
+
+namespace Al {
+namespace internal {
+namespace ht {
+
+template <typename T>
+class AllgathervAlState : public HostTransferCollectiveSignalAtEndState {
+public:
+  AllgathervAlState(const T* sendbuf, T* recvbuf,
+                    std::vector<size_t> counts_, std::vector<size_t> displs_,
+                    HostTransferCommunicator& comm_, cudaStream_t stream_) :
+    HostTransferCollectiveSignalAtEndState(stream_),
+    host_mem(get_pinned_memory<T>(displs_.back()+counts_.back())),
+    counts(mpi::intify_size_t_vector(counts_)),
+    displs(mpi::intify_size_t_vector(displs_)),
+    comm(comm_.get_comm()) {
+    // Transfer data from device to host.
+    if (sendbuf == recvbuf) {
+      AL_CHECK_CUDA(cudaMemcpyAsync(host_mem + displs_[comm_.rank()],
+                                    sendbuf + displs_[comm_.rank()],
+                                    sizeof(T)*counts_[comm_.rank()],
+                                    cudaMemcpyDeviceToHost,
+                                    stream_));
+    } else {
+      AL_CHECK_CUDA(cudaMemcpyAsync(host_mem + displs_[comm_.rank()],
+                                    sendbuf, sizeof(T)*counts_[comm_.rank()],
+                                    cudaMemcpyDeviceToHost, stream_));
+    }
+    start_event.record(stream_);
+
+    // Have the device wait on the host.
+    gpu_wait.wait(stream_);
+
+    // Transfer completed buffer back to device.
+    AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem,
+                                  sizeof(T)*(displs_.back()+counts_.back()),
+                                  cudaMemcpyHostToDevice, stream_));
+    end_event.record(stream_);
+  }
+
+  ~AllgathervAlState() override {
+    release_pinned_memory(host_mem);
+  }
+
+  std::string get_name() const override { return "HTAllgatherv"; }
+
+protected:
+  void start_mpi_op() override {
+    MPI_Iallgatherv(MPI_IN_PLACE, 0, mpi::TypeMap<T>(),
+                    host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
+                    comm, get_mpi_req());
+  }
+
+private:
+  T* host_mem;
+  std::vector<int> counts;
+  std::vector<int> displs;
+  MPI_Comm comm;
+};
+
+}  // namespace ht
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/ht/alltoall.hpp
+++ b/include/aluminum/ht/alltoall.hpp
@@ -29,99 +29,51 @@
 
 #include "aluminum/cuda.hpp"
 #include "aluminum/ht/communicator.hpp"
-#include "aluminum/progress.hpp"
+#include "aluminum/ht/base_state.hpp"
 
 namespace Al {
 namespace internal {
 namespace ht {
 
 template <typename T>
-class AlltoallAlState : public AlState {
+class AlltoallAlState : public HostTransferCollectiveSignalAtEndState {
 public:
-  AlltoallAlState(const T* sendbuf, T* recvbuf, size_t count,
-                  HostTransferCommunicator& comm, cudaStream_t stream) :
-    AlState(nullptr),
-    host_mem_(get_pinned_memory<T>(comm.size()*count)),
-    count_(count),
-    comm_(comm.get_comm()),
-    compute_stream(comm.get_stream()) {
+  AlltoallAlState(const T* sendbuf, T* recvbuf, size_t count_,
+                  HostTransferCommunicator& comm_, cudaStream_t stream_) :
+    HostTransferCollectiveSignalAtEndState(stream_),
+    host_mem(get_pinned_memory<T>(comm_.size()*count_)),
+    count(count_),
+    comm(comm_.get_comm()) {
+    // Transfer data from device to host.
+    AL_CHECK_CUDA(cudaMemcpyAsync(host_mem, sendbuf, sizeof(T)*count*comm_.size(),
+                                  cudaMemcpyDeviceToHost, stream_));
+    start_event.record(stream_);
 
-    // Transfer data from device to host and use an event to determine when it
-    // completes.
-    AL_CHECK_CUDA(cudaMemcpyAsync(host_mem_, sendbuf, sizeof(T)*count*comm.size(),
-                                  cudaMemcpyDeviceToHost, stream));
-    d2h_event_.record(stream);
-
-    // Enqueue the kernel to wait on the host
-    gpuwait_.wait(stream);
+    // Have the device wait on the host.
+    gpu_wait.wait(stream_);
 
     // Transfer completed buffer back to device.
-    AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem_, sizeof(T)*count*comm.size(),
-                                  cudaMemcpyHostToDevice, stream));
-    h2d_event_.record(stream);
+    AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem, sizeof(T)*count*comm_.size(),
+                                  cudaMemcpyHostToDevice, stream_));
+    end_event.record(stream_);
   }
 
   ~AlltoallAlState() override {
-    release_pinned_memory(host_mem_);
+    release_pinned_memory(host_mem);
   }
-
-  PEAction step() override {
-    if (!mem_xfer_done_) {
-      if (d2h_event_.query()) {
-        mem_xfer_done_ = true;
-        return PEAction::advance;
-      } else {
-        return PEAction::cont;
-      }
-    }
-    if (!a2a_started_) {
-      MPI_Ialltoall(MPI_IN_PLACE, count_, mpi::TypeMap<T>(),
-                    host_mem_, count_, mpi::TypeMap<T>(), comm_, &req_);
-      a2a_started_ = true;
-    }
-
-    if (!a2a_done_) {
-      // Wait for the all2all to complete
-      int flag;
-      MPI_Test(&req_, &flag, MPI_STATUS_IGNORE);
-      if (flag) {
-        a2a_done_ = true;
-        gpuwait_.signal();
-      }
-      else {
-        return PEAction::cont;
-      }
-    }
-
-    // Wait for host-to-device memcopy; cleanup
-    if (h2d_event_.query()) {
-      return PEAction::complete;
-    }
-
-    return PEAction::cont;
-  }
-
-  bool needs_completion() const override { return false; }
-  void* get_compute_stream() const override { return compute_stream; }
 
   std::string get_name() const override { return "HTAlltoall"; }
 
+protected:
+  void start_mpi_op() override {
+    MPI_Ialltoall(MPI_IN_PLACE, count, mpi::TypeMap<T>(),
+                  host_mem, count, mpi::TypeMap<T>(), comm, get_mpi_req());
+  }
+
 private:
-  T* host_mem_;
-  size_t count_;
-
-  cuda::GPUWait gpuwait_;
-
-  cuda::FastEvent d2h_event_, h2d_event_;
-
-  MPI_Comm comm_;
-  MPI_Request req_ = MPI_REQUEST_NULL;
-
-  bool mem_xfer_done_ = false;
-  bool a2a_started_ = false;
-  bool a2a_done_ = false;
-
-  cudaStream_t compute_stream;
+  T* host_mem;
+  size_t count;
+  MPI_Comm comm;
 };
 
 }  // namespace ht

--- a/include/aluminum/ht/alltoallv.hpp
+++ b/include/aluminum/ht/alltoallv.hpp
@@ -1,0 +1,125 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "aluminum/cuda.hpp"
+#include "aluminum/ht/communicator.hpp"
+#include "aluminum/ht/base_state.hpp"
+
+namespace Al {
+namespace internal {
+namespace ht {
+
+template <typename T>
+class AlltoallvAlState : public HostTransferCollectiveSignalAtEndState {
+public:
+  AlltoallvAlState(const T* sendbuf,
+                   std::vector<size_t> send_counts_,
+                   std::vector<size_t> send_displs_,
+                   T* recvbuf,
+                   std::vector<size_t> recv_counts_,
+                   std::vector<size_t> recv_displs_,
+                   HostTransferCommunicator& comm_, cudaStream_t stream_) :
+    HostTransferCollectiveSignalAtEndState(stream_),
+    inplace(sendbuf == recvbuf),
+    host_sendbuf(inplace ?
+                 nullptr :
+                 get_pinned_memory<T>(send_displs_.back() + send_counts_.back())),
+    host_recvbuf(get_pinned_memory<T>(recv_displs_.back() + recv_counts_.back())),
+    send_counts(mpi::intify_size_t_vector(send_counts_)),
+    send_displs(mpi::intify_size_t_vector(send_displs_)),
+    recv_counts(mpi::intify_size_t_vector(recv_counts_)),
+    recv_displs(mpi::intify_size_t_vector(recv_displs_)),
+    comm(comm_.get_comm()) {
+    // Transfer data from device to host.
+    // We need to distinguish the inplace case in case the sendbuf is
+    // larger than the recvbuf.
+    // We may be able to optimize this into a single transfer in certain cases.
+    if (inplace) {
+      // If doing an in-place operation, transfer directly to host_recvbuf.
+      for (size_t i = 0; i < recv_counts_.size(); ++i) {
+        AL_CHECK_CUDA(cudaMemcpyAsync(host_recvbuf + recv_displs_[i],
+                                      recvbuf + recv_displs_[i],
+                                      sizeof(T)*recv_counts_[i],
+                                      cudaMemcpyDeviceToHost, stream_));
+      }
+    } else {
+      for (size_t i = 0; i < send_counts_.size(); ++i) {
+        AL_CHECK_CUDA(cudaMemcpyAsync(host_sendbuf + send_displs_[i],
+                                      sendbuf + send_displs_[i],
+                                      sizeof(T)*send_counts_[i],
+                                      cudaMemcpyDeviceToHost, stream_));
+      }
+    }
+    start_event.record(stream_);
+
+    // Have the device wait on the host.
+    gpu_wait.wait(stream_);
+
+    // Transfer completed buffer back to device.
+    for (size_t i = 0; i < recv_counts_.size(); ++i) {
+      AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf + recv_displs_[i],
+                                    host_recvbuf + recv_displs_[i],
+                                    sizeof(T)*recv_counts_[i],
+                                    cudaMemcpyDeviceToHost, stream_));
+    }
+    end_event.record(stream_);
+  }
+
+  ~AlltoallvAlState() override {
+    if (host_sendbuf) {
+      release_pinned_memory(host_sendbuf);
+    }
+    release_pinned_memory(host_recvbuf);
+  }
+
+  std::string get_name() const override { return "HTAlltoallv"; }
+
+protected:
+  void start_mpi_op() override {
+    MPI_Ialltoallv(inplace ? MPI_IN_PLACE : host_sendbuf,
+                   send_counts.data(), send_displs.data(), mpi::TypeMap<T>(),
+                   host_recvbuf,
+                   recv_counts.data(), recv_displs.data(), mpi::TypeMap<T>(),
+                   comm, get_mpi_req());
+  }
+
+private:
+  bool inplace;
+  T* host_sendbuf = nullptr;
+  T* host_recvbuf = nullptr;
+  std::vector<int> send_counts;
+  std::vector<int> send_displs;
+  std::vector<int> recv_counts;
+  std::vector<int> recv_displs;
+  MPI_Comm comm;
+};
+
+}  // namespace ht
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/ht/barrier.hpp
+++ b/include/aluminum/ht/barrier.hpp
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "aluminum/cuda.hpp"
+#include "aluminum/ht/communicator.hpp"
+#include "aluminum/ht/base_state.hpp"
+
+namespace Al {
+namespace internal {
+namespace ht {
+
+class BarrierAlState : public HostTransferCollectiveSignalAtEndState {
+public:
+  BarrierAlState(HostTransferCommunicator& comm_, cudaStream_t stream_) :
+    HostTransferCollectiveSignalAtEndState(stream_),
+    comm(comm_.get_comm()) {
+    // Just wait until we should start this.
+    start_event.record(stream_);
+
+    // Have the device wait on the host.
+    gpu_wait.wait(stream_);
+  }
+
+  std::string get_name() const override { return "HTBarrier"; }
+
+protected:
+  void start_mpi_op() override {
+    MPI_Ibarrier(comm, get_mpi_req());
+  }
+
+private:
+  MPI_Comm comm;
+};
+
+}  // namespace ht
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/ht/base_state.hpp
+++ b/include/aluminum/ht/base_state.hpp
@@ -1,0 +1,215 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "aluminum/progress.hpp"
+#include "aluminum/cuda.hpp"
+
+namespace Al {
+namespace internal {
+namespace ht {
+
+/** Base implementation for common host-transfer collectives. */
+class HostTransferCollectiveState : public AlState {
+public:
+  HostTransferCollectiveState(cudaStream_t stream_) :
+    AlState(nullptr), stream(stream_) {}
+
+  bool needs_completion() const override { return false; }
+  void *get_compute_stream() const override { return stream; }
+
+protected:
+  /** Start the MPI operation and set the request. */
+  virtual void start_mpi_op() = 0;
+  /** Return the MPI request that will be polled on. */
+  MPI_Request* get_mpi_req() { return &mpi_req; }
+  /** Return true when the MPI operation is complete. */
+  virtual bool poll_mpi() {
+    int flag;
+    MPI_Test(get_mpi_req(), &flag, MPI_STATUS_IGNORE);
+    return flag;
+  }
+
+  // These are protected to simplify child implementations.
+
+  /** Event that when complete indicates communication can begin. */
+  cuda::FastEvent start_event;
+  /** Whether start_event has completed. */
+  bool start_done = false;
+  /** Event that when complete indicates all device operations are done. */
+  cuda::FastEvent end_event;
+  /** Whether the MPI operation has been started. */
+  bool mpi_started = false;
+  /** Whether the MPI operation has completed. */
+  bool mpi_done = false;
+  /** GPU-side wait. */
+  cuda::GPUWait gpu_wait;
+
+private:
+  /** Associated compute stream. */
+  cudaStream_t stream;
+  /** Internal MPI request handle. */
+  MPI_Request mpi_req = MPI_REQUEST_NULL;
+};
+
+/**
+ * This implements a step method that signals the GPU wait only after
+ * communication has completed.
+ */
+class HostTransferCollectiveSignalAtEndState : public HostTransferCollectiveState {
+public:
+  HostTransferCollectiveSignalAtEndState(cudaStream_t stream_) :
+    HostTransferCollectiveState(stream_) {}
+
+  PEAction step() override {
+    if (!start_done) {
+      if (start_event.query()) {
+        start_done = true;
+        return PEAction::advance;
+      } else {
+        return PEAction::cont;
+      }
+    }
+    if (!mpi_started) {
+      start_mpi_op();
+      mpi_started = true;
+    }
+    if (!mpi_done) {
+      if (poll_mpi()) {
+        mpi_done = true;
+        gpu_wait.signal();
+      } else {
+        return PEAction::cont;
+      }
+    }
+    if (end_event.query()) {
+      return PEAction::complete;
+    }
+    return PEAction::cont;
+  }
+};
+
+/**
+ * This implements a step method that signals the GPU wait after the
+ * start event completes on the root, and after communication has
+ * completed elsewhere.
+ */
+class HostTransferCollectiveSignalRootEarlyState : public HostTransferCollectiveState {
+ public:
+  HostTransferCollectiveSignalRootEarlyState(bool is_root_, cudaStream_t stream_) :
+    HostTransferCollectiveState(stream_), is_root(is_root_) {}
+
+  PEAction step() override {
+    if (!start_done) {
+      if (start_event.query()) {
+        start_done = true;
+        return PEAction::advance;
+      } else {
+        return PEAction::cont;
+      }
+    }
+    if (!mpi_started) {
+      start_mpi_op();
+      mpi_started = true;
+      if (is_root) {
+        gpu_wait.signal();
+      }
+    }
+    if (!mpi_done) {
+      if (poll_mpi()) {
+        mpi_done = true;
+        if (!is_root) {
+          gpu_wait.signal();
+        } else {
+          return PEAction::complete;
+        }
+      } else {
+        return PEAction::cont;
+      }
+    }
+    if (end_event.query()) {
+      return PEAction::complete;
+    }
+    return PEAction::cont;
+  }
+
+ protected:
+  bool is_root;
+};
+
+/**
+ * This implements a step method that signals the GPU wait after the
+ * start event completes on non-root processes, and after communication
+ * has completed on the root.
+ */
+class HostTransferCollectiveSignalNonRootEarlyState : public HostTransferCollectiveState {
+ public:
+  HostTransferCollectiveSignalNonRootEarlyState(bool is_root_, cudaStream_t stream_) :
+    HostTransferCollectiveState(stream_), is_root(is_root_) {}
+
+  PEAction step() override {
+    if (!start_done) {
+      if (start_event.query()) {
+        start_done = true;
+        return PEAction::advance;
+      } else {
+        return PEAction::cont;
+      }
+    }
+    if (!mpi_started) {
+      start_mpi_op();
+      mpi_started = true;
+      if (!is_root) {
+        gpu_wait.signal();
+      }
+    }
+    if (!mpi_done) {
+      if (poll_mpi()) {
+        mpi_done = true;
+        if (is_root) {
+          gpu_wait.signal();
+        } else {
+          return PEAction::complete;
+        }
+      } else {
+        return PEAction::cont;
+      }
+    }
+    if (end_event.query()) {
+      return PEAction::complete;
+    }
+    return PEAction::cont;
+  }
+
+ protected:
+  bool is_root;
+};
+
+}  // namespace ht
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/ht/bcast.hpp
+++ b/include/aluminum/ht/bcast.hpp
@@ -29,112 +29,57 @@
 
 #include "aluminum/cuda.hpp"
 #include "aluminum/ht/communicator.hpp"
-#include "aluminum/progress.hpp"
+#include "aluminum/ht/base_state.hpp"
 
 namespace Al {
 namespace internal {
 namespace ht {
 
 template <typename T>
-class BcastAlState : public AlState {
+class BcastAlState : public HostTransferCollectiveSignalRootEarlyState {
 public:
-  BcastAlState(T* buf, size_t count, int root,
-               HostTransferCommunicator& comm, cudaStream_t stream) :
-    AlState(nullptr),
-    rank_(comm.rank()), root_(root), count_(count),
-    host_mem_(get_pinned_memory<T>(count_)),
-    comm_(comm.get_comm()),
-    compute_stream(comm.get_stream()) {
-
-    bool const i_am_root = rank_ == root_;
-
-    // Transfer data from device to host and use an event to determine when it
-    // completes.
-    if (i_am_root) {
+  BcastAlState(T* buf, size_t count_, int root_,
+               HostTransferCommunicator& comm_, cudaStream_t stream_) :
+    HostTransferCollectiveSignalRootEarlyState(comm_.rank() == root_, stream_),
+    host_mem(get_pinned_memory<T>(count_)),
+    count(count_),
+    root(root_),
+    comm(comm_.get_comm()) {
+    // Transfer data from device to host.
+    if (is_root) {
       AL_CHECK_CUDA(cudaMemcpyAsync(
-                      host_mem_, buf, sizeof(T)*count_,
-                      cudaMemcpyDeviceToHost, stream));
+                      host_mem, buf, sizeof(T)*count,
+                      cudaMemcpyDeviceToHost, stream_));
     }
-    d2h_event_.record(stream);
-    gpuwait_.wait(stream);
+    start_event.record(stream_);
 
-    if (!i_am_root) {
+    // Have the device wait on the host.
+    gpu_wait.wait(stream_);
+
+    if (!is_root) {
       // Transfer completed buffer back to device.
-      AL_CHECK_CUDA(cudaMemcpyAsync(buf, host_mem_, sizeof(T)*count_,
-                                    cudaMemcpyHostToDevice, stream));
-      h2d_event_.record(stream);
+      AL_CHECK_CUDA(cudaMemcpyAsync(buf, host_mem, sizeof(T)*count,
+                                    cudaMemcpyHostToDevice, stream_));
+      end_event.record(stream_);
     }
   }
 
   ~BcastAlState() override {
-    release_pinned_memory(host_mem_);
+    release_pinned_memory(host_mem);
   }
-
-  PEAction step() override {
-    if (!mem_xfer_done_) {
-      if (d2h_event_.query()) {
-        mem_xfer_done_ = true;
-        return PEAction::advance;
-      } else {
-        return PEAction::cont;
-      }
-    }
-    if (!bcast_started_) {
-      MPI_Ibcast(host_mem_, count_, mpi::TypeMap<T>(),
-                 root_, comm_, &req_);
-      if (rank_ == root_) {
-        gpuwait_.signal();
-      }
-      bcast_started_ = true;
-    }
-
-    if (!bcast_done_) {
-      // Wait for the bcast to complete
-      int flag;
-      MPI_Test(&req_, &flag, MPI_STATUS_IGNORE);
-      if (flag) {
-        bcast_done_ = true;
-        if (rank_ != root_) {
-          gpuwait_.signal();
-        } else {
-          return PEAction::complete;
-        }
-      }
-      else {
-        return PEAction::cont;
-      }
-    }
-
-    // Wait for host-to-device memcopy; cleanup
-    if (h2d_event_.query()) {
-      return PEAction::complete;
-    }
-    return PEAction::cont;
-  }
-
-  bool needs_completion() const override { return false; }
-  void* get_compute_stream() const override { return compute_stream; }
 
   std::string get_name() const override { return "HTBcast"; }
 
+protected:
+  void start_mpi_op() override {
+    MPI_Ibcast(host_mem, count, mpi::TypeMap<T>(), root, comm, get_mpi_req());
+  }
+
 private:
-  int rank_;
-  int root_;
-  size_t count_;
-  T* host_mem_;
-
-  cuda::GPUWait gpuwait_;
-
-  cuda::FastEvent d2h_event_, h2d_event_;
-
-  MPI_Comm comm_;
-  MPI_Request req_ = MPI_REQUEST_NULL;
-
-  bool mem_xfer_done_ = false;
-  bool bcast_started_ = false;
-  bool bcast_done_ = false;
-
-  cudaStream_t compute_stream;
+  T* host_mem;
+  size_t count;
+  int root;
+  MPI_Comm comm;
 };
 
 }  // namespace ht

--- a/include/aluminum/ht/gatherv.hpp
+++ b/include/aluminum/ht/gatherv.hpp
@@ -1,0 +1,110 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "aluminum/cuda.hpp"
+#include "aluminum/ht/communicator.hpp"
+#include "aluminum/ht/base_state.hpp"
+
+namespace Al {
+namespace internal {
+namespace ht {
+
+template <typename T>
+class GathervAlState : public HostTransferCollectiveSignalNonRootEarlyState {
+public:
+  GathervAlState(const T* sendbuf, T* recvbuf,
+                 std::vector<size_t> counts_, std::vector<size_t> displs_,
+                 int root_,
+                 HostTransferCommunicator& comm_, cudaStream_t stream_) :
+    HostTransferCollectiveSignalNonRootEarlyState(comm_.rank() == root_, stream_),
+    host_mem(get_pinned_memory<T>((comm_.rank() == root_) ?
+                                  (displs_.back() + counts_.back()) :
+                                  counts_[comm_.rank()])),
+    send_count(counts_[comm_.rank()]),
+    counts(mpi::intify_size_t_vector(counts_)),
+    displs(mpi::intify_size_t_vector(displs_)),
+    root(root_),
+    comm(comm_.get_comm()) {
+    // Transfer data from device to host.
+    if (is_root) {
+      AL_CHECK_CUDA(cudaMemcpyAsync(
+                      host_mem + displs_[comm_.rank()],
+                      (sendbuf == recvbuf) ? sendbuf + displs_[comm_.rank()] : sendbuf,
+                      sizeof(T) * counts_[comm_.rank()],
+                      cudaMemcpyDeviceToHost, stream_));
+    } else {
+      AL_CHECK_CUDA(cudaMemcpyAsync(host_mem, sendbuf,
+                                    sizeof(T) * counts_[comm_.rank()],
+                                    cudaMemcpyDeviceToHost, stream_));
+    }
+    start_event.record(stream_);
+
+    // Have the device wait on the host.
+    gpu_wait.wait(stream_);
+
+    if (is_root) {
+      // Transfer completed buffer back to device.
+      AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem,
+                                    sizeof(T) * (displs_.back() + counts_.back()),
+                                    cudaMemcpyHostToDevice, stream_));
+      end_event.record(stream_);
+    }
+  }
+
+  ~GathervAlState() override {
+    release_pinned_memory(host_mem);
+  }
+
+  std::string get_name() const override { return "HTGatherv"; }
+
+protected:
+  void start_mpi_op() override {
+    if (is_root) {
+      MPI_Igatherv(MPI_IN_PLACE, send_count, mpi::TypeMap<T>(),
+                   host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
+                   root, comm, get_mpi_req());
+    } else {
+      MPI_Igatherv(host_mem, send_count, mpi::TypeMap<T>(),
+                   host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
+                   root, comm, get_mpi_req());
+    }
+  }
+
+private:
+  T* host_mem;
+  size_t send_count;
+  std::vector<int> counts;
+  std::vector<int> displs;
+  int root;
+  MPI_Comm comm;
+};
+
+}  // namespace ht
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/ht/reduce_scatterv.hpp
+++ b/include/aluminum/ht/reduce_scatterv.hpp
@@ -1,0 +1,88 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "aluminum/cuda.hpp"
+#include "aluminum/ht/communicator.hpp"
+#include "aluminum/ht/base_state.hpp"
+
+namespace Al {
+namespace internal {
+namespace ht {
+
+template <typename T>
+class ReduceScattervAlState : public HostTransferCollectiveSignalAtEndState {
+public:
+  ReduceScattervAlState(const T* sendbuf, T* recvbuf,
+                        std::vector<size_t> counts_,
+                       ReductionOperator op_, HostTransferCommunicator& comm_,
+                       cudaStream_t stream_) :
+    HostTransferCollectiveSignalAtEndState(stream_),
+    total_size(std::accumulate(counts_.begin(), counts_.end(), 0)),
+    host_mem(get_pinned_memory<T>(total_size)),
+    counts(mpi::intify_size_t_vector(counts_)),
+    op(mpi::ReductionOperator2MPI_Op(op_)),
+    comm(comm_.get_comm()) {
+    // Transfer data from device to host.
+    AL_CHECK_CUDA(cudaMemcpyAsync(host_mem, sendbuf, sizeof(T)*total_size,
+                                  cudaMemcpyDeviceToHost, stream_));
+    start_event.record(stream_);
+
+    // Have the device wait on the host.
+    gpu_wait.wait(stream_);
+
+    // Transfer completed buffer back to device.
+    AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem,
+                                  sizeof(T)*counts_[comm_.rank()],
+                                  cudaMemcpyHostToDevice, stream_));
+    end_event.record(stream_);
+  }
+
+  ~ReduceScattervAlState() override {
+    release_pinned_memory(host_mem);
+  }
+
+  std::string get_name() const override { return "HTReduceScatterv"; }
+
+protected:
+  void start_mpi_op() override {
+    MPI_Ireduce_scatter(MPI_IN_PLACE, host_mem, counts.data(),
+                        mpi::TypeMap<T>(), op, comm, get_mpi_req());
+  }
+
+private:
+  size_t total_size;
+  T* host_mem;
+  std::vector<int> counts;
+  MPI_Op op;
+  MPI_Comm comm;
+};
+
+}  // namespace ht
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/ht/scatterv.hpp
+++ b/include/aluminum/ht/scatterv.hpp
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "aluminum/cuda.hpp"
+#include "aluminum/ht/communicator.hpp"
+#include "aluminum/ht/base_state.hpp"
+
+namespace Al {
+namespace internal {
+namespace ht {
+
+template <typename T>
+class ScattervAlState : public HostTransferCollectiveSignalRootEarlyState {
+public:
+  ScattervAlState(const T* sendbuf, T* recvbuf,
+                  std::vector<size_t> counts_, std::vector<size_t> displs_,
+                  int root_,
+                  HostTransferCommunicator& comm_, cudaStream_t stream_) :
+    HostTransferCollectiveSignalRootEarlyState(comm_.rank() == root_, stream_),
+    host_mem(get_pinned_memory<T>((comm_.rank() == root_) ?
+                                  (displs_.back() + counts_.back()) :
+                                  counts_[comm_.rank()])),
+    recv_count(counts_[comm_.rank()]),
+    counts(mpi::intify_size_t_vector(counts_)),
+    displs(mpi::intify_size_t_vector(displs_)),
+    root(root_),
+    comm(comm_.get_comm()) {
+    if (is_root) {
+      // Transfer the data from device to host.
+      for (size_t i = 0; i < counts_.size(); ++i) {
+        AL_CHECK_CUDA(cudaMemcpyAsync(
+                        host_mem + displs_[i], sendbuf + displs_[i],
+                        sizeof(T) * counts_[i],
+                        cudaMemcpyDeviceToHost, stream_));
+      }
+      start_event.record(stream_);
+      // Root only needs to copy its data to its final destination on the
+      // device when it's not in place.
+      if (sendbuf != recvbuf) {
+        AL_CHECK_CUDA(cudaMemcpyAsync(
+                        recvbuf, sendbuf + displs_[comm_.rank()],
+                        sizeof(T) * counts_[comm_.rank()],
+                        cudaMemcpyDeviceToDevice, stream_));
+      }
+      // Have the device wait on the host.
+      gpu_wait.wait(stream_);
+    } else {
+      // Need to ensure communication is not started early.
+      start_event.record(stream_);
+      // Have the device wait on the host.
+      gpu_wait.wait(stream_);
+      // Transfer completed buffer back to device.
+      AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem,
+                                    sizeof(T)*counts_[comm_.rank()],
+                                    cudaMemcpyHostToDevice, stream_));
+      end_event.record(stream_);
+    }
+  }
+
+  ~ScattervAlState() override {
+    release_pinned_memory(host_mem);
+  }
+
+  std::string get_name() const override { return "HTScatterv"; }
+
+protected:
+  void start_mpi_op() override {
+    if (is_root) {
+      MPI_Iscatterv(host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
+                   MPI_IN_PLACE, recv_count, mpi::TypeMap<T>(),
+                   root, comm, get_mpi_req());
+    } else {
+      MPI_Iscatterv(host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
+                   host_mem, recv_count, mpi::TypeMap<T>(),
+                   root, comm, get_mpi_req());
+    }
+  }
+
+private:
+  T* host_mem;
+  size_t recv_count;
+  std::vector<int> counts;
+  std::vector<int> displs;
+  int root;
+  MPI_Comm comm;
+};
+
+}  // namespace ht
+}  // namespace internal
+}  // namespace Al

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -77,7 +77,7 @@ test_cases = {
         'datatypes': nccl_datatypes
     },
     'ht': {
-        'ops': coll_ops + pt2pt_ops,
+        'ops': coll_ops + vector_coll_ops + pt2pt_ops,
         'datatypes': mpi_datatypes
     },
 }

--- a/test/test_utils_ht.hpp
+++ b/test/test_utils_ht.hpp
@@ -70,19 +70,19 @@ void complete_operations<Al::HostTransferBackend>(
 
 // Operator support.
 template <> struct IsOpSupported<AlOperation::allgather, Al::HostTransferBackend> : std::true_type {};
-//template <> struct IsOpSupported<AlOperation::allgatherv, Al::HostTransferBackend> : std::true_type {};
+template <> struct IsOpSupported<AlOperation::allgatherv, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::allreduce, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::alltoall, Al::HostTransferBackend> : std::true_type {};
-//template <> struct IsOpSupported<AlOperation::alltoallv, Al::HostTransferBackend> : std::true_type {};
+template <> struct IsOpSupported<AlOperation::alltoallv, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::bcast, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::barrier, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::gather, Al::HostTransferBackend> : std::true_type {};
-//template <> struct IsOpSupported<AlOperation::gatherv, Al::HostTransferBackend> : std::true_type {};
+template <> struct IsOpSupported<AlOperation::gatherv, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::reduce, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::reduce_scatter, Al::HostTransferBackend> : std::true_type {};
-//template <> struct IsOpSupported<AlOperation::reduce_scatterv, Al::HostTransferBackend> : std::true_type {};
+template <> struct IsOpSupported<AlOperation::reduce_scatterv, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::scatter, Al::HostTransferBackend> : std::true_type {};
-//template <> struct IsOpSupported<AlOperation::scatterv, Al::HostTransferBackend> : std::true_type {};
+template <> struct IsOpSupported<AlOperation::scatterv, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::send, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::recv, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::sendrecv, Al::HostTransferBackend> : std::true_type {};
@@ -114,18 +114,18 @@ template <> constexpr char AlBackendName<Al::HostTransferBackend>[] = "ht";
 template <> struct OpAlgoType<AlOperation::allgather, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::allgather_algo_type;
 };
-/*template <> struct OpAlgoType<AlOperation::allgatherv, Al::HostTransferBackend> {
+template <> struct OpAlgoType<AlOperation::allgatherv, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::allgatherv_algo_type;
-  };*/
+};
 template <> struct OpAlgoType<AlOperation::allreduce, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::allreduce_algo_type;
 };
 template <> struct OpAlgoType<AlOperation::alltoall, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::alltoall_algo_type;
 };
-/*template <> struct OpAlgoType<AlOperation::alltoallv, Al::HostTransferBackend> {
+template <> struct OpAlgoType<AlOperation::alltoallv, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::alltoallv_algo_type;
-  };*/
+};
 template <> struct OpAlgoType<AlOperation::barrier, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::barrier_algo_type;
 };
@@ -135,24 +135,24 @@ template <> struct OpAlgoType<AlOperation::bcast, Al::HostTransferBackend> {
 template <> struct OpAlgoType<AlOperation::gather, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::gather_algo_type;
 };
-/*template <> struct OpAlgoType<AlOperation::gatherv, Al::HostTransferBackend> {
+template <> struct OpAlgoType<AlOperation::gatherv, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::gatherv_algo_type;
-  };*/
+};
 template <> struct OpAlgoType<AlOperation::reduce, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::reduce_algo_type;
 };
 template <> struct OpAlgoType<AlOperation::reduce_scatter, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::reduce_scatter_algo_type;
 };
-/*template <> struct OpAlgoType<AlOperation::reduce_scatterv, Al::HostTransferBackend> {
+template <> struct OpAlgoType<AlOperation::reduce_scatterv, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::reduce_scatterv_algo_type;
-  };*/
+};
 template <> struct OpAlgoType<AlOperation::scatter, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::scatter_algo_type;
 };
-/*template <> struct OpAlgoType<AlOperation::scatterv, Al::HostTransferBackend> {
+template <> struct OpAlgoType<AlOperation::scatterv, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::scatterv_algo_type;
-  };*/
+};
 
 // Supported algorithms.
 template <>
@@ -167,25 +167,30 @@ template <>
 struct AlgorithmOptions<Al::HostTransferBackend> {
   typename Al::HostTransferBackend::allgather_algo_type allgather_algo =
     Al::HostTransferBackend::allgather_algo_type::automatic;
-  //typename Al::HostTransferBackend::allgatherv_algo_type allgatherv_algo;
+  typename Al::HostTransferBackend::allgatherv_algo_type allgatherv_algo =
+    Al::HostTransferBackend::allgatherv_algo_type::automatic;
   typename Al::HostTransferBackend::allreduce_algo_type allreduce_algo =
     Al::HostTransferBackend::allreduce_algo_type::automatic;
   typename Al::HostTransferBackend::alltoall_algo_type alltoall_algo =
     Al::HostTransferBackend::alltoall_algo_type::automatic;
-  //typename Al::HostTransferBackend::alltoallv_algo_type alltoallv_algo;
+  typename Al::HostTransferBackend::alltoallv_algo_type alltoallv_algo =
+    Al::HostTransferBackend::alltoallv_algo_type::automatic;
   typename Al::HostTransferBackend::barrier_algo_type barrier_algo =
     Al::HostTransferBackend::barrier_algo_type::automatic;
   typename Al::HostTransferBackend::bcast_algo_type bcast_algo =
     Al::HostTransferBackend::bcast_algo_type::automatic;
   typename Al::HostTransferBackend::gather_algo_type gather_algo =
     Al::HostTransferBackend::gather_algo_type::automatic;
-  //typename Al::HostTransferBackend::gatherv_algo_type gatherv_algo;
+  typename Al::HostTransferBackend::gatherv_algo_type gatherv_algo =
+    Al::HostTransferBackend::gatherv_algo_type::automatic;
   typename Al::HostTransferBackend::reduce_algo_type reduce_algo =
     Al::HostTransferBackend::reduce_algo_type::automatic;
   typename Al::HostTransferBackend::reduce_scatter_algo_type reduce_scatter_algo =
     Al::HostTransferBackend::reduce_scatter_algo_type::automatic;
-  //typename Al::HostTransferBackend::reduce_scatterv_algo_type reduce_scatterv_algo;
+  typename Al::HostTransferBackend::reduce_scatterv_algo_type reduce_scatterv_algo =
+    Al::HostTransferBackend::reduce_scatterv_algo_type::automatic;
   typename Al::HostTransferBackend::scatter_algo_type scatter_algo =
     Al::HostTransferBackend::scatter_algo_type::automatic;
-  //typename Al::HostTransferBackend::scatterv_algo_type scatterv_algo;
+  typename Al::HostTransferBackend::scatterv_algo_type scatterv_algo =
+    Al::HostTransferBackend::scatterv_algo_type::automatic;
 };

--- a/test/test_utils_ht.hpp
+++ b/test/test_utils_ht.hpp
@@ -75,6 +75,7 @@ template <> struct IsOpSupported<AlOperation::allreduce, Al::HostTransferBackend
 template <> struct IsOpSupported<AlOperation::alltoall, Al::HostTransferBackend> : std::true_type {};
 //template <> struct IsOpSupported<AlOperation::alltoallv, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::bcast, Al::HostTransferBackend> : std::true_type {};
+template <> struct IsOpSupported<AlOperation::barrier, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::gather, Al::HostTransferBackend> : std::true_type {};
 //template <> struct IsOpSupported<AlOperation::gatherv, Al::HostTransferBackend> : std::true_type {};
 template <> struct IsOpSupported<AlOperation::reduce, Al::HostTransferBackend> : std::true_type {};
@@ -125,6 +126,9 @@ template <> struct OpAlgoType<AlOperation::alltoall, Al::HostTransferBackend> {
 /*template <> struct OpAlgoType<AlOperation::alltoallv, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::alltoallv_algo_type;
   };*/
+template <> struct OpAlgoType<AlOperation::barrier, Al::HostTransferBackend> {
+  using type = Al::HostTransferBackend::barrier_algo_type;
+};
 template <> struct OpAlgoType<AlOperation::bcast, Al::HostTransferBackend> {
   using type = Al::HostTransferBackend::bcast_algo_type;
 };
@@ -169,6 +173,8 @@ struct AlgorithmOptions<Al::HostTransferBackend> {
   typename Al::HostTransferBackend::alltoall_algo_type alltoall_algo =
     Al::HostTransferBackend::alltoall_algo_type::automatic;
   //typename Al::HostTransferBackend::alltoallv_algo_type alltoallv_algo;
+  typename Al::HostTransferBackend::barrier_algo_type barrier_algo =
+    Al::HostTransferBackend::barrier_algo_type::automatic;
   typename Al::HostTransferBackend::bcast_algo_type bcast_algo =
     Al::HostTransferBackend::bcast_algo_type::automatic;
   typename Al::HostTransferBackend::gather_algo_type gather_algo =


### PR DESCRIPTION
Depends on #111.

Add support for `allgatherv`, `alltoallv`, `gatherv`, `reduce_scatterv`, and `scatterv` to the host-transfer backend.

Tests pass.