### PR TITLE
Associate internal streams with requests

### DIFF
--- a/include/aluminum/cuda.hpp
+++ b/include/aluminum/cuda.hpp
@@ -31,6 +31,7 @@
 
 #include <utility>
 #include <sstream>
+#include <functional>
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -149,6 +150,16 @@ void release_cuda_event(cudaEvent_t event);
 cudaStream_t get_internal_stream();
 /** Get a specific internal stream. */
 cudaStream_t get_internal_stream(size_t id);
+/**
+ * Replace the internal stream pool with user-provided streams.
+ *
+ * stream_getter may be called an arbitrary number of times and should
+ * return the streams to use in the pool.
+ *
+ * This is meant to help interface with external applications that
+ * need Aluminum to use their streams for everything.
+ */
+void replace_internal_streams(std::function<cudaStream_t()> stream_getter);
 
 /** Return whether stream memory operations are supported. */
 bool stream_memory_operations_supported();


### PR DESCRIPTION
Depends on #112.

This adds a field to the `NCCLRequest` and `HostTransferRequest` objects to hold the internal stream (i.e., the stream an operation is actually running on). This is mostly an implementation detail, but certain external interfaces using Aluminum may need this information. (For example, PyTorch needs this so its memory allocator does not free data early.)

This also supports replacing the entire internal stream pool with externally-provided streams.

I don't want this to be explicitly part of the public API, but certain things may rely on it.