### PR TITLE
Support for serializing MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,10 @@ option(ALUMINUM_ENABLE_TRACE
   "Enable runtime tracing."
   OFF)
 
+option(ALUMINUM_MPI_SERIALIZE
+  "Serialize MPI operations."
+  OFF)
+
 option(ALUMINUM_ENABLE_TESTS
   "Build tests."
   OFF)
@@ -132,6 +136,9 @@ if (ALUMINUM_ENABLE_STREAM_MEM_OPS)
 endif ()
 if (ALUMINUM_ENABLE_TRACE)
   set(AL_TRACE ON)
+endif ()
+if (ALUMINUM_MPI_SERIALIZE)
+  set(AL_MPI_SERIALIZE ON)
 endif ()
 if (ALUMINUM_ENABLE_TESTS)
   set(AL_ENABLE_TESTS ON)

--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -20,3 +20,5 @@
 #cmakedefine01 AL_USE_STREAM_MEM_OPS
 
 #cmakedefine AL_TRACE
+
+#cmakedefine AL_MPI_SERIALIZE


### PR DESCRIPTION
Depends on #123.

When the `ALUMINUM_MPI_SERIALIZE` option is set, this will initialize MPI with `MPI_THREAD_SERIALIZED` and run all blocking MPI calls on the progress engine thread (instead of the calling thread) transparently.