### PR TITLE
Progress engine thread safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,9 @@ option(ALUMINUM_ENABLE_NVPROF
 option(ALUMINUM_ENABLE_STREAM_MEM_OPS
   "Enable stream memory operations."
   OFF)
+option(ALUMINUM_ENABLE_THREAD_MULTIPLE
+  "Allow multiple threads to call Aluminum concurrently."
+  OFF)
 option(ALUMINUM_ENABLE_TRACE
   "Enable runtime tracing."
   OFF)
@@ -133,6 +136,9 @@ if (ALUMINUM_DEBUG_HANG_CHECK)
 endif ()
 if (ALUMINUM_ENABLE_STREAM_MEM_OPS)
   set(AL_USE_STREAM_MEM_OPS ON)
+endif ()
+if (ALUMINUM_ENABLE_THREAD_MULTIPLE)
+  set(AL_THREAD_MULTIPLE ON)
 endif ()
 if (ALUMINUM_ENABLE_TRACE)
   set(AL_TRACE ON)

--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -19,6 +19,9 @@
 /** Whether to use stream memory operations (if supported). */
 #cmakedefine01 AL_USE_STREAM_MEM_OPS
 
+/** Whether to support multiple threads calling Aluminum concurrently. */
+#cmakedefine AL_THREAD_MULTIPLE
+
 #cmakedefine AL_TRACE
 
 #cmakedefine AL_MPI_SERIALIZE

--- a/include/aluminum/CMakeLists.txt
+++ b/include/aluminum/CMakeLists.txt
@@ -6,6 +6,7 @@ set_source_path(THIS_DIR_HEADERS
   mpi_comm_and_stream_wrapper.hpp
   mpi_impl.hpp
   profiling.hpp
+  state.hpp
   trace.hpp
   tuning_params.hpp
   )

--- a/include/aluminum/cuda/sync_memory.hpp
+++ b/include/aluminum/cuda/sync_memory.hpp
@@ -44,10 +44,12 @@ namespace cuda {
  * cache line.
  */
 struct CacheLinePinnedMemoryAllocator {
-  int32_t* allocate() {
-    int32_t* mem = (int32_t*) std::aligned_alloc(
-      AL_CACHE_LINE_SIZE, sizeof(int32_t));
-    AL_CHECK_CUDA(cudaHostRegister(mem, sizeof(int32_t), cudaHostRegisterDefault));
+  int32_t *allocate() {
+    // Overallocate to avoid interference.
+    int32_t *mem = (int32_t *)std::aligned_alloc(
+        AL_DESTRUCTIVE_INTERFERENCE_SIZE, AL_DESTRUCTIVE_INTERFERENCE_SIZE);
+    AL_CHECK_CUDA(cudaHostRegister(mem, AL_DESTRUCTIVE_INTERFERENCE_SIZE,
+                                   cudaHostRegisterDefault));
     return mem;
   }
 

--- a/include/aluminum/mpi/communicator.hpp
+++ b/include/aluminum/mpi/communicator.hpp
@@ -28,7 +28,6 @@
 #pragma once
 
 #include <mpi.h>
-#include "Al.hpp"
 #include "aluminum/mpi_comm_and_stream_wrapper.hpp"
 
 namespace Al {

--- a/include/aluminum/mpi_comm_and_stream_wrapper.hpp
+++ b/include/aluminum/mpi_comm_and_stream_wrapper.hpp
@@ -28,7 +28,6 @@
 #pragma once
 
 #include <mpi.h>
-#include "Al.hpp"
 
 namespace Al {
 namespace internal {

--- a/include/aluminum/progress.hpp
+++ b/include/aluminum/progress.hpp
@@ -42,21 +42,13 @@
 #include <ostream>
 #include <array>
 
-namespace Al {
-
-// Forward declaration.
-class Communicator;
-
-}  // namespace Al
-
+#include "aluminum/base.hpp"
+#include "aluminum/tuning_params.hpp"
 #include "aluminum/mpi/communicator.hpp"
+#include "aluminum/profiling.hpp"
 
 namespace Al {
 namespace internal {
-// Forward declaration.
-namespace profiling {
-struct ProfileRange;
-}
 
 /**
  * Request handle for non-blocking operations.

--- a/include/aluminum/progress.hpp
+++ b/include/aluminum/progress.hpp
@@ -233,61 +233,6 @@ struct InputQueue {
 };
 
 /**
- * An fixed-length ordered array that allows arbitrary elements to be removed.
- * This is meant to be used for small N.
- */
-template <size_t N>
-struct OrderedArray {
-  OrderedArray() {
-    std::fill_n(l, N, nullptr);
-  }
-  ~OrderedArray() {}
-  /** Whether the array is currently full. */
-  bool full() const { return cur_size == N; }
-  /**
-   * Add an element to the end of the array.
-   * This assumes the array is not full.
-   */
-  void push(AlState* v) {
-    l[cur_size] = v;
-    ++cur_size;
-  }
-  /**
-   * Delete an entry.
-   * This assumes idx exists.
-   */
-  void del(size_t idx) {
-    // Just copy the elements over.
-    for (size_t i = idx; i < cur_size - 1; ++i) {
-      l[i] = l[i+1];
-    }
-    --cur_size;
-  }
-  /**
-   * Fill "holes" created by marking elements null.
-   */
-  void compact() {
-    size_t free_slot = 0;
-    for (size_t i = 0; i < cur_size; ++i) {
-      if (l[i] != nullptr) {
-        // l[i] has something, see if we can move it into the free slot.
-        if (free_slot < i) {
-          l[free_slot] = l[i];
-        }
-        // Advance the free slot. If we copied something over, everything after
-        // should be shifted too.
-        ++free_slot;
-      }
-    }
-    cur_size = free_slot;
-  }
-  /** Underlying data store. */
-  AlState* l[N];
-  /** Number of elements currently present. */
-  size_t cur_size = 0;
-};
-
-/**
  * Encapsulates the asynchronous progress engine.
  * Note this is intended to be used from only one thread (in addition to the
  * progress thread) and is not optimized (or tested) for other cases.

--- a/include/aluminum/state.hpp
+++ b/include/aluminum/state.hpp
@@ -1,0 +1,131 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <memory>
+#include <atomic>
+
+#include "aluminum/profiling.hpp"
+
+namespace Al {
+namespace internal {
+
+// TODO: Get rid of AlRequest, since it's only used by the MPI backend.
+
+/**
+ * Request handle for non-blocking operations.
+ * The atomic flag is used to check for completion.
+ */
+using AlRequest = std::shared_ptr<std::atomic<bool>>;
+/** Return a free request for use. */
+inline AlRequest get_free_request() {
+  return std::make_shared<std::atomic<bool>>(false);
+}
+/** Special marker for null requests. */
+static constexpr std::nullptr_t NULL_REQUEST = nullptr;
+/** Special marker for the default compute stream. */
+static constexpr std::nullptr_t DEFAULT_STREAM = nullptr;
+/** Run queue types for the progress engine. */
+enum class RunType {
+  /** Only a limited number of ops will be run at a time. */
+  bounded,
+  /** There cannot be a limit on how many ops of this type will run. */
+  unbounded
+};
+
+/** Actions a state can ask the progress engine to do. */
+enum class PEAction {
+  /** Do nothing (i.e. keep running as it is now). */
+  cont,
+  /** Advance the state to the next pipeline stage. */
+  advance,
+  /** Operation is complete. */
+  complete
+};
+
+/**
+ * Represents the state and algorithm for an asynchronous operation.
+ * A non-blocking operation should create one of these and enqueue it for
+ * execution by the progress thread. Specific implementations can override
+ * as needed.
+ *
+ * An algorithm should be broken up into steps which execute some small,
+ * discrete operation. Steps from different operations may be interleaved.
+ * Note that the memory pool is not thread-safe, so memory from it should be
+ * pre-allocated before enqueueing.
+ *
+ * The steps are run through a simple pipeline. The algorithm can request it
+ * advance to the next stage by returning PEAction::advance. Operations enqueud
+ * on the same compute stream will only be advanced in the order they were
+ * enqueued. If a state asks to advance but it is not at the head of its
+ * pipeline stage, step will not be called again until it has successfully
+ * advanced.
+ */
+class AlState {
+  friend class ProgressEngine;
+ public:
+  /** Create with an associated request. */
+  AlState(AlRequest req_) : req(req_) {}
+  virtual ~AlState() { profiling::prof_end(prof_range); }
+  /**
+   * Perform initial setup of the algorithm.
+   * This is called by the progress engine when the operation begins execution.
+   */
+  virtual void start() { prof_range = profiling::prof_start(get_name()); }
+  /**
+   * Run one step of the algorithm.
+   * Return the action the algorithm wishes the progress engine to take.
+   */
+  virtual PEAction step() = 0;
+  /** Return the associated request. */
+  AlRequest& get_req() { return req; }
+  /** True if this is meant to be waited on by the user. */
+  virtual bool needs_completion() const { return true; }
+  /** Return the compute stream associated with this operation. */
+  virtual void* get_compute_stream() const { return DEFAULT_STREAM; }
+  /** Return the run queue type this operation should use. */
+  virtual RunType get_run_type() const { return RunType::bounded; }
+  /** True if this is meant to block operations until completion. */
+  virtual bool blocks() const { return false; }
+  /** Return a name identifying the state (for debugging/info purposes). */
+  virtual std::string get_name() const { return "AlState"; }
+  /** Return a string description of the state (for debugging/info purposes). */
+  virtual std::string get_desc() const { return ""; }
+ private:
+  AlRequest req;
+#ifdef AL_DEBUG_HANG_CHECK
+  bool hang_reported = false;
+  double start_time = std::numeric_limits<double>::max();
+#endif
+  profiling::ProfileRange prof_range;
+  /** Whether execution of this operation is paused on pipeline advancement. */
+  bool paused_for_advance = false;
+};
+
+}  // namespace internal
+}  // namespace Al

--- a/include/aluminum/tuning_params.hpp
+++ b/include/aluminum/tuning_params.hpp
@@ -49,11 +49,20 @@
 #define AL_SYNC_MEM_PREALLOC 1024
 
 /**
- * Cache line size.
+ * Cache line size in bytes.
  *
  * On x86 this is usually 64. On POWER this is 128. On A64FX this is 256.
  */
 #define AL_CACHE_LINE_SIZE 64
+
+/**
+ * Minimum size in bytes to avoid destructive interference.
+ *
+ * This is generally AL_CACHE_LINE_SIZE, except on x86, where it should
+ * be twice the cache line size, because Intel processors can fetch
+ * two adjacent cache lines (see Intel Optimization Manual, 3.7.3).
+ */
+#define AL_DESTRUCTIVE_INTERFERENCE_SIZE 128
 
 /** Number of CUDA streams in the default stream pool. */
 #define AL_CUDA_STREAM_POOL_SIZE 5

--- a/include/aluminum/tuning_params.hpp
+++ b/include/aluminum/tuning_params.hpp
@@ -32,15 +32,31 @@
  */
 #pragma once
 
-/**
- * Number of concurrent operations the progress engine will perform.
- * This must be a positive number.
- */
+/** Number of concurrent operations the progress engine will perform. */
 #define AL_PE_NUM_CONCURRENT_OPS 4
 /** Max number of streams the progress engine supports. */
 #define AL_PE_NUM_STREAMS 64
 /** Max number of pipeline stages the progress engine supports. */
 #define AL_PE_NUM_PIPELINE_STAGES 2
+/** Max number of entries in each stream's input queue. */
+#define AL_PE_INPUT_QUEUE_SIZE 8192
+/**
+ * Whether to have a default stream entry for the progress engine
+ * added automatically.
+ *
+ * This makes sense when using MPI, but not so when using the
+ * host-transfer backend, which does not use the default stream.
+ */
+// #define AL_PE_ADD_DEFAULT_STREAM 1
+/**
+ * Whether to use a thread-local cache to map streams to input queues
+ * for the progress engine.
+ *
+ * If you expect to have only a small number of streams, using a cache
+ * is unlikely to help, since searching it will take as long as
+ * searching the actual list.
+ */
+// #define AL_PE_STREAM_QUEUE_CACHE 1
 
 /** Whether to protect memory pools with locks. */
 #define AL_LOCK_MEMPOOL 1

--- a/include/aluminum/tuning_params.hpp
+++ b/include/aluminum/tuning_params.hpp
@@ -58,9 +58,6 @@
  */
 // #define AL_PE_STREAM_QUEUE_CACHE 1
 
-/** Whether to protect memory pools with locks. */
-#define AL_LOCK_MEMPOOL 1
-
 /** Amount of sync object memory to preallocate in the pool. */
 #define AL_SYNC_MEM_PREALLOC 1024
 

--- a/include/aluminum/utils/CMakeLists.txt
+++ b/include/aluminum/utils/CMakeLists.txt
@@ -2,6 +2,7 @@ set_source_path(THIS_DIR_HEADERS
   caching_allocator.hpp
   locked_resource_pool.hpp
   meta.hpp
+  spsc_queue.hpp
   utils.hpp
   )
 

--- a/include/aluminum/utils/CMakeLists.txt
+++ b/include/aluminum/utils/CMakeLists.txt
@@ -2,6 +2,7 @@ set_source_path(THIS_DIR_HEADERS
   caching_allocator.hpp
   locked_resource_pool.hpp
   meta.hpp
+  mpsc_queue.hpp
   spsc_queue.hpp
   utils.hpp
   )

--- a/include/aluminum/utils/mpsc_queue.hpp
+++ b/include/aluminum/utils/mpsc_queue.hpp
@@ -43,12 +43,16 @@ namespace internal {
 template <typename T>
 class MPSCQueue {
 public:
-  /** Initialize queue with fixed size (must be a power of 2). */
+  /**
+   * Initialize queue with fixed size (must be a power of 2).
+   *
+   * The queue will hold at most size - 1 elements.
+   */
   explicit MPSCQueue(size_t size_) : size(size_), index(1) {
     static_assert(std::is_pointer<T>::value, "T must be a pointer type");
 #ifdef AL_DEBUG
     if (!is_pow2(size)) {
-      throw_al_exception("SPSCQueue size must be a power of 2");
+      throw_al_exception("MPSCQueue size must be a power of 2");
     }
 #endif
     data = new queue_entry[size + 1];

--- a/include/aluminum/utils/spsc_queue.hpp
+++ b/include/aluminum/utils/spsc_queue.hpp
@@ -1,0 +1,132 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <Al_config.hpp>
+
+#include <atomic>
+#include <algorithm>
+#include "aluminum/base.hpp"
+#include "aluminum/tuning_params.hpp"
+#include "aluminum/utils/meta.hpp"
+
+namespace Al {
+namespace internal {
+
+/**
+ * Bounded, lock-free, single-producer, single-consumer queue.
+ *
+ * This is Lamport's classic SPSC queue with memory order optimizations.
+ * See Le, et al. "Correct and Efficient Bounded FIFO Queues".
+ */
+template <typename T>
+class SPSCQueue {
+public:
+  /** Initialize queue with fixed size (must be a power of 2). */
+  explicit SPSCQueue(size_t size_) : size(size_), front(0), back(0) {
+#ifdef AL_DEBUG
+    if (!is_pow2(size)) {
+      throw_al_exception("SPSCQueue size must be a power of 2");
+    }
+#endif
+    data = new T[size];
+    std::fill_n(data, size, nullptr);
+  }
+
+  ~SPSCQueue() {
+    delete[] data;
+  }
+
+  /** Add v to the queue. */
+  void push(T& v) {
+    size_t b = back.load(std::memory_order_relaxed);
+    size_t bmod = (b+1) & (size-1);
+#ifdef AL_DEBUG
+    size_t f = front.load(std::memory_order_acquire);
+    if (bmod == f) {
+      throw_al_exception("Queue full");
+    }
+#endif
+    data[b] = v;
+    back.store(bmod, std::memory_order_release);
+  }
+
+  /** Return the next element in the queue; nullptr if empty. */
+  T pop() {
+    size_t f = front.load(std::memory_order_relaxed);
+    size_t b = back.load(std::memory_order_acquire);
+    if (b == f) {
+      return nullptr;
+    }
+    T* v = data[f];
+    front.store((f+1) & (size-1), std::memory_order_release);
+    return v;
+  }
+
+  /**
+   * Discard the element at the front of the queue.
+   *
+   * It is an error to call this if no element is present.
+   */
+  void pop_always() {
+    size_t f = front.load(std::memory_order_relaxed);
+#ifdef AL_DEBUG
+    size_t b = back.load(std::memory_order_acquire);
+    if (b == f) {
+      throw_al_exception("Tried to pop_always when empty");
+    }
+#endif
+    front.store((f+1) & (size-1), std::memory_order_release);
+  }
+
+  /** Return the next element in the queue; nullptr if empty. */
+  T peek() {
+    size_t f = front.load(std::memory_order_relaxed);
+    size_t b = back.load(std::memory_order_acquire);
+    if (b == f) {
+      return nullptr;
+    }
+    return data[f];
+  }
+
+private:
+  /** Number of elements the queue can store. */
+  const size_t size;
+  /** Buffer for data in the queue. */
+  T* data;
+  /** Index for the current front of the queue. */
+  alignas(AL_DESTRUCTIVE_INTERFERENCE_SIZE) std::atomic<size_t> front;
+  /** Index for the current back of the queue. */
+  alignas(AL_DESTRUCTIVE_INTERFERENCE_SIZE) std::atomic<size_t> back;
+
+  // Prevent allocations on the cache line back is in.
+  char padding[AL_DESTRUCTIVE_INTERFERENCE_SIZE - sizeof(std::atomic<size_t>)];
+};
+
+}  // namespace internal
+}  // namespace Al

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -168,19 +168,6 @@ int get_hwloc_offset(
 
 }  // anonymous namespace
 
-
-AlState::~AlState() {
-  profiling::prof_end(prof_range);
-}
-
-void AlState::start() {
-  prof_range = profiling::prof_start(get_name());
-}
-
-AlRequest get_free_request() {
-  return std::make_shared<std::atomic<bool>>(false);
-}
-
 ProgressEngine::ProgressEngine() {
   stop_flag = false;
   started_flag = false;

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -261,7 +261,7 @@ std::ostream& ProgressEngine::dump_state(std::ostream& ss) {
       }
     }
   }
-  const size_t req_queue_size = num_input_streams.load();
+  /*const size_t req_queue_size = num_input_streams.load();
   ss << "Request queues (" << req_queue_size << "):\n";
   for (size_t i = 0; i < req_queue_size; ++i) {
     ss << i << ": blocked=" << request_queues[i].blocked;
@@ -272,7 +272,7 @@ std::ostream& ProgressEngine::dump_state(std::ostream& ss) {
       ss << "\t" << j << ": " << request_queues[i].q.data[j]->get_name()
          << " " << request_queues[i].q.data[j]->get_desc() << "\n";
     }
-  }
+    }*/
   return ss;
 }
 


### PR DESCRIPTION
Depends on #126.

This adds support for multiple threads to enqueue operations on the progress engine concurrently. This support is enabled when compiling with `ALUMINUM_ENABLE_THREAD_MULTIPLE` set. This PR passes all our existing tests, but note we have no tests for multi-threaded calls to operations. I defer that to a subsequent PR.

This PR does several things:
* Cleans up some of the internal progress engine implementation and reorganizes code.
* The SPSC queue the progress engine used was split out and (somewhat) generalized. It only supports pointer types right now, but can be generalized.
* An MPSC queue was added.
* Some additional tuning parameters were introduced:
  * `AL_DESTRUCTIVE_INTERFERENCE_SIZE` was added to complement `AL_CACHE_LINE_SIZE`. (Some code was changed to use the former now.)
  * `AL_PE_INPUT_QUEUE_SIZE` was added to avoid a hard-coded constant.
  * `AL_PE_ADD_DEFAULT_STREAM` controls whether the progress engine includes a default input queue for the default compute stream (CPU).
  * `AL_PE_STREAM_QUEUE_CACHE` controls whether the progress engine uses a thread-local lookup map to cache input queues for streams.