### PR TITLE
Multi-threaded testing

### DIFF
--- a/test/cuda_vector.hpp
+++ b/test/cuda_vector.hpp
@@ -75,7 +75,7 @@ class CUDAVector {
 
   void clear() {
     if (m_count > 0) {
-      AL_FORCE_CHECK_CUDA_NOSYNC(cudaFree(m_ptr));
+      Al::internal::mempool.release<Al::internal::MemoryType::CUDA>(m_ptr);
       m_ptr = nullptr;
       m_count = 0;
     }
@@ -84,17 +84,8 @@ class CUDAVector {
   void allocate() {
     assert(m_ptr == nullptr);
     if (m_count > 0) {
-      cudaError_t e = cudaMalloc(&m_ptr, get_bytes());
-      if (e != cudaSuccess) {
-        size_t free_mem, total_mem;
-        cudaMemGetInfo(&free_mem, &total_mem);
-        std::cerr << "Error allocating "
-                  << get_bytes() << " bytes of memory: "
-                  << cudaGetErrorString(e)
-                  << ", free: " << free_mem << "\n";
-        cudaDeviceReset();
-        std::abort();
-      }
+      m_ptr = Al::internal::mempool.allocate<Al::internal::MemoryType::CUDA, T>(
+        m_count, m_stream);
     }
   }
 

--- a/test/cuda_vector.hpp
+++ b/test/cuda_vector.hpp
@@ -67,6 +67,7 @@ class CUDAVector {
     using std::swap;
     swap(x.m_count, y.m_count);
     swap(x.m_ptr, y.m_ptr);
+    swap(x.m_stream, y.m_stream);
   }
 
   size_t size() const {
@@ -140,6 +141,9 @@ class CUDAVector {
 
   void sync_memcpy(void* dst, const void* src, size_t count,
                    cudaMemcpyKind kind) const {
+    if (count == 0) {
+      return;
+    }
     AL_FORCE_CHECK_CUDA_NOSYNC(
       cudaMemcpyAsync(dst, src, count, kind, m_stream));
     AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamSynchronize(m_stream));

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -36,6 +36,8 @@ parser.add_argument('--blocking', default=None, action='store_true',
                     help='Run only blocking algorithms')
 parser.add_argument('--nonblocking', default=None, action='store_true',
                     help='Run only nonblocking algorithms')
+parser.add_argument('--threads', type=int, default=None,
+                    help='Number of threads to test with')
 
 
 # Supported datatypes for backends.
@@ -137,6 +139,8 @@ def run_test(args, num_procs, backend, operator, datatype, inplace,
                 '--max-size', '2048',
                 # Don't wait too long.
                 '--hang-timeout', '5']
+    if args.threads is not None:
+        test_cmd += ['--threads', str(args.threads)]
     test_desc = f'procs:{num_procs} {backend} {operator} {datatype}'
     if inplace:
         test_cmd += ['--inplace']

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -138,7 +138,8 @@ def run_test(args, num_procs, backend, operator, datatype, inplace,
                 # Keep things relatively small.
                 '--max-size', '2048',
                 # Don't wait too long.
-                '--hang-timeout', '5']
+                '--hang-timeout', '5',
+                '--dump-on-error', '--max-dump-size', '64']
     if args.threads is not None:
         test_cmd += ['--threads', str(args.threads)]
     test_desc = f'procs:{num_procs} {backend} {operator} {datatype}'

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -209,8 +209,6 @@ void run_test_instance(AlOperation op, OpOptions<Backend> op_options,
       Al::Wait<Backend>(op_options.req);
     }
   }
-
-  MPI_Barrier(comm_wrapper.comm().get_comm());
 }
 
 template <typename Backend, typename T,
@@ -349,6 +347,7 @@ void run_test(cxxopts::ParseResult& parsed_opts) {
       }
       for (int i = 0; i < num; ++i) {
         complete_operations<Backend>(comm_wrappers[i].comm());
+        MPI_Barrier(comm_wrapper.comm().get_comm());
       }
       watchdog.finish();
       // Run MPI baseline and check.

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -61,7 +61,7 @@ struct VectorType {
   using type = std::vector<T>;
 
   /** Generate a vector of random data of size count. */
-  static type gen_data(size_t count) {
+  static type gen_data(size_t count, int = 0) {
     static bool rng_seeded = false;
     static std::minstd_rand rng_gen;
     if (!rng_seeded) {
@@ -100,8 +100,9 @@ struct CommWrapper {
   std::unique_ptr<typename Backend::comm_type> comm_;
   CommWrapper(MPI_Comm mpi_comm) :
     comm_(std::make_unique<typename Backend::comm_type>(mpi_comm)) {}
-  // Not noexcept because CUDA specializations might throw.
-  ~CommWrapper() noexcept(false) {};
+  CommWrapper(CommWrapper<Backend>&& other) = default;
+  CommWrapper<Backend>& operator=(CommWrapper<Backend>&& other) = default;
+  ~CommWrapper() {};
   typename Backend::comm_type& comm() { return *comm_; }
   const typename Backend::comm_type& comm() const { return *comm_; }
   int rank() const { return comm_->rank(); }

--- a/test/test_utils_ht.hpp
+++ b/test/test_utils_ht.hpp
@@ -38,9 +38,9 @@ template <typename T>
 struct VectorType<T, Al::HostTransferBackend> {
   using type = CUDAVector<T>;
 
-  static type gen_data(size_t count) {
+  static type gen_data(size_t count, cudaStream_t stream = 0) {
     auto&& host_data = VectorType<T, Al::MPIBackend>::gen_data(count);
-    CUDAVector<T> data(host_data);
+    CUDAVector<T> data(host_data, stream);
     return data;
   }
 
@@ -58,8 +58,17 @@ CommWrapper<Al::HostTransferBackend>::CommWrapper(MPI_Comm mpi_comm) {
     mpi_comm, stream);
 }
 template <>
-CommWrapper<Al::HostTransferBackend>::~CommWrapper() noexcept(false) {
-  AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamDestroy(comm_->get_stream()));
+CommWrapper<Al::HostTransferBackend>::~CommWrapper() {
+  if (comm_) {
+    try {
+      AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamDestroy(comm_->get_stream()));
+    } catch (const Al::al_exception &e) {
+      std::cerr
+          << "Caught exception in CommWrapper<HostTransferBackend> destructor: "
+          << e.what() << std::endl;
+      std::terminate();
+    }
+  }
 }
 
 template <>

--- a/test/test_utils_nccl.hpp
+++ b/test/test_utils_nccl.hpp
@@ -38,9 +38,9 @@ template <typename T>
 struct VectorType<T, Al::NCCLBackend> {
   using type = CUDAVector<T>;
 
-  static type gen_data(size_t count) {
+  static type gen_data(size_t count, cudaStream_t stream = 0) {
     auto&& host_data = VectorType<T, Al::MPIBackend>::gen_data(count);
-    CUDAVector<T> data(host_data);
+    CUDAVector<T> data(host_data, stream);
     return data;
   }
 
@@ -53,13 +53,13 @@ struct VectorType<T, Al::NCCLBackend> {
 template <> struct VectorType<__half, Al::NCCLBackend> {
   using type = CUDAVector<__half>;
 
-  static type gen_data(size_t count) {
+  static type gen_data(size_t count, cudaStream_t stream = 0) {
     auto&& host_data = VectorType<float, Al::MPIBackend>::gen_data(count);
     std::vector<__half> host_data_half(count);
     for (size_t i = 0; i < count; ++i) {
       host_data_half[i] = __float2half(host_data[i]);
     }
-    CUDAVector<__half> data(host_data_half);
+    CUDAVector<__half> data(host_data_half, stream);
     return data;
   }
 
@@ -77,8 +77,16 @@ CommWrapper<Al::NCCLBackend>::CommWrapper(MPI_Comm mpi_comm) {
     mpi_comm, stream);
 }
 template <>
-CommWrapper<Al::NCCLBackend>::~CommWrapper() noexcept(false) {
-  AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamDestroy(comm_->get_stream()));
+CommWrapper<Al::NCCLBackend>::~CommWrapper() {
+  if (comm_) {
+    try {
+      AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamDestroy(comm_->get_stream()));
+    } catch (const Al::al_exception &e) {
+      std::cerr << "Caught exception in CommWrapper<NCCLBackend> destructor: "
+                << e.what() << std::endl;
+      std::terminate();
+    }
+  }
 }
 
 template <>


### PR DESCRIPTION
This depends on #127.

This adds support to the testing infrastructure for using multiple threads to perform tests, controlled with the `--threads` argument (the default behavior is no threads, as before). When using multiple threads, separate communicators will be created for each thread (on each rank, of course), which will isolate the communication logically, but communication is otherwise performed concurrently.

This also fixes several issues in the testing code that impacted multi-threaded testing, mostly with the host-transfer backend. These are primarily related to CUDA calls implicitly performing synchronization.