### PR TITLE
Fix potential host-transfer bug

### DIFF
--- a/include/aluminum/ht/barrier.hpp
+++ b/include/aluminum/ht/barrier.hpp
@@ -45,6 +45,7 @@ public:
 
     // Have the device wait on the host.
     gpu_wait.wait(stream_);
+    end_event.record(stream_);
   }
 
   std::string get_name() const override { return "HTBarrier"; }

--- a/include/aluminum/ht/base_state.hpp
+++ b/include/aluminum/ht/base_state.hpp
@@ -148,8 +148,6 @@ class HostTransferCollectiveSignalRootEarlyState : public HostTransferCollective
         mpi_done = true;
         if (!is_root) {
           gpu_wait.signal();
-        } else {
-          return PEAction::complete;
         }
       } else {
         return PEAction::cont;
@@ -196,8 +194,6 @@ class HostTransferCollectiveSignalNonRootEarlyState : public HostTransferCollect
         mpi_done = true;
         if (is_root) {
           gpu_wait.signal();
-        } else {
-          return PEAction::complete;
         }
       } else {
         return PEAction::cont;

--- a/include/aluminum/ht/bcast.hpp
+++ b/include/aluminum/ht/bcast.hpp
@@ -60,8 +60,8 @@ public:
       // Transfer completed buffer back to device.
       AL_CHECK_CUDA(cudaMemcpyAsync(buf, host_mem, sizeof(T)*count,
                                     cudaMemcpyHostToDevice, stream_));
-      end_event.record(stream_);
     }
+    end_event.record(stream_);
   }
 
   ~BcastAlState() override {

--- a/include/aluminum/ht/gather.hpp
+++ b/include/aluminum/ht/gather.hpp
@@ -65,8 +65,8 @@ public:
       // Transfer completed buffer back to device.
       AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem, sizeof(T)*count*comm_.size(),
                                     cudaMemcpyHostToDevice, stream_));
-      end_event.record(stream_);
     }
+    end_event.record(stream_);
   }
 
   ~GatherAlState() override {

--- a/include/aluminum/ht/gatherv.hpp
+++ b/include/aluminum/ht/gatherv.hpp
@@ -73,8 +73,8 @@ public:
       AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem,
                                     sizeof(T) * (displs_.back() + counts_.back()),
                                     cudaMemcpyHostToDevice, stream_));
-      end_event.record(stream_);
     }
+    end_event.record(stream_);
   }
 
   ~GathervAlState() override {

--- a/include/aluminum/ht/reduce.hpp
+++ b/include/aluminum/ht/reduce.hpp
@@ -58,8 +58,8 @@ public:
       // Transfer completed buffer back to device.
       AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem, sizeof(T)*count,
                                     cudaMemcpyHostToDevice, stream_));
-      end_event.record(stream_);
     }
+    end_event.record(stream_);
   }
 
   ~ReduceAlState() override {

--- a/include/aluminum/ht/scatter.hpp
+++ b/include/aluminum/ht/scatter.hpp
@@ -69,8 +69,8 @@ public:
       // Transfer completed buffer back to device.
       AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem, sizeof(T)*count,
                                     cudaMemcpyHostToDevice, stream_));
-      end_event.record(stream_);
     }
+    end_event.record(stream_);
   }
 
   ~ScatterAlState() override {

--- a/include/aluminum/ht/scatterv.hpp
+++ b/include/aluminum/ht/scatterv.hpp
@@ -79,8 +79,8 @@ public:
       AL_CHECK_CUDA(cudaMemcpyAsync(recvbuf, host_mem,
                                     sizeof(T)*counts_[comm_.rank()],
                                     cudaMemcpyHostToDevice, stream_));
-      end_event.record(stream_);
     }
+    end_event.record(stream_);
   }
 
   ~ScattervAlState() override {


### PR DESCRIPTION
Depends on #128.

Certain host-transfer collectives could complete on the host and release their host-side memory before they complete on the GPU. This means that memory used by synchronization objects could be reused before the GPU side completes. This ensures that does not occur.