### PR TITLE
Fix too many streams when testing

### DIFF
--- a/include/aluminum/cuda/streams.hpp
+++ b/include/aluminum/cuda/streams.hpp
@@ -46,7 +46,7 @@ namespace cuda {
 class StreamPool {
 public:
   /** Create pool with num_streams default and high priority streams. */
-  StreamPool(size_t num_streams);
+  StreamPool(size_t num_streams = 0);
   ~StreamPool();
 
   /** Explicitly allocate streams. */

--- a/include/aluminum/utils/mpsc_queue.hpp
+++ b/include/aluminum/utils/mpsc_queue.hpp
@@ -48,7 +48,11 @@ public:
    *
    * The queue will hold at most size - 1 elements.
    */
-  explicit MPSCQueue(size_t size_) : size(size_), index(1) {
+  explicit MPSCQueue(size_t size_)
+#ifndef AL_DEBUG
+    noexcept
+#endif
+    : size(size_), index(1) {
     static_assert(std::is_pointer<T>::value, "T must be a pointer type");
 #ifdef AL_DEBUG
     if (!is_pow2(size)) {
@@ -66,7 +70,11 @@ public:
   }
 
   /** Add v to the queue. */
-  void push(T& v) {
+  void push(T& v)
+#ifndef AL_DEBUG
+    noexcept
+#endif
+  {
     size_t i = index.fetch_add(1);
     queue_entry* entry = &data[i & (size - 1)];
     entry->value = v;
@@ -96,7 +104,7 @@ public:
   }
 
   /** Return the next element in the queue; nullptr if empty. */
-  T pop() {
+  T pop() noexcept {
     if (head->next == nullptr) {
       return nullptr;
     }
@@ -110,7 +118,11 @@ public:
    *
    * It is an error to call this if no element is present.
    */
-  void pop_always() {
+  void pop_always()
+#ifndef AL_DEBUG
+    noexcept
+#endif
+  {
 #ifdef AL_DEBUG
     if (head->next == nullptr) {
       throw_al_exception("Tried to pop_always when empty");
@@ -120,7 +132,7 @@ public:
   }
 
   /** Return the next element in the queue; nullptr if empty. */
-  T peek() {
+  T peek() noexcept {
     return (head->next == nullptr) ? nullptr : head->next->value;
   }
 

--- a/include/aluminum/utils/mpsc_queue.hpp
+++ b/include/aluminum/utils/mpsc_queue.hpp
@@ -52,7 +52,11 @@ public:
 #ifndef AL_DEBUG
     noexcept
 #endif
-    : size(size_), index(1) {
+    : size(size_), index(1)
+#ifdef AL_DEBUG
+    , cur_size(0)
+#endif
+  {
     static_assert(std::is_pointer<T>::value, "T must be a pointer type");
 #ifdef AL_DEBUG
     if (!is_pow2(size)) {
@@ -82,6 +86,11 @@ public:
     queue_entry* old_tail;
     queue_entry* old_next;
     while (true) {
+#ifdef AL_DEBUG
+      if (cur_size.load() + 1 >= size - 1) {
+        throw_al_exception("Queue full");
+      }
+#endif
       old_tail = tail;
       old_next = tail->next;
       if (old_tail == tail) {
@@ -96,6 +105,9 @@ public:
             // Update the tail.
             __atomic_compare_exchange_n(&tail, &old_tail, entry, true,
                                         __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+#ifdef AL_DEBUG
+            ++cur_size;
+#endif
             break;
           }
         }
@@ -110,6 +122,9 @@ public:
     }
     T value = head->next->value;
     head = head->next;
+#ifdef AL_DEBUG
+    --cur_size;
+#endif
     return value;
   }
 
@@ -129,6 +144,9 @@ public:
     }
 #endif
     head = head->next;
+#ifdef AL_DEBUG
+    --cur_size;
+#endif
   }
 
   /** Return the next element in the queue; nullptr if empty. */
@@ -149,6 +167,10 @@ private:
   queue_entry* data;
   /** Current index in data. */
   alignas(AL_DESTRUCTIVE_INTERFERENCE_SIZE) std::atomic<size_t> index;
+#ifdef AL_DEBUG
+  /** Used for best-effort debugging to detect queue overflows. */
+  alignas(AL_DESTRUCTIVE_INTERFERENCE_SIZE) std::atomic<size_t> cur_size;
+#endif
   /** Pointer to the current head of the queue. */
   alignas(AL_DESTRUCTIVE_INTERFERENCE_SIZE) queue_entry* head;
   /** Pointer to the current tail of the queue. */

--- a/include/aluminum/utils/spsc_queue.hpp
+++ b/include/aluminum/utils/spsc_queue.hpp
@@ -49,7 +49,11 @@ template <typename T>
 class SPSCQueue {
 public:
   /** Initialize queue with fixed size (must be a power of 2). */
-  explicit SPSCQueue(size_t size_) : size(size_), front(0), back(0) {
+  explicit SPSCQueue(size_t size_)
+#ifndef AL_DEBUG
+    noexcept
+#endif
+    : size(size_), front(0), back(0) {
     static_assert(std::is_pointer<T>::value, "T must be a pointer type");
 #ifdef AL_DEBUG
     if (!is_pow2(size)) {
@@ -65,7 +69,11 @@ public:
   }
 
   /** Add v to the queue. */
-  void push(T& v) {
+  void push(T& v)
+#ifndef AL_DEBUG
+    noexcept
+#endif
+  {
     size_t b = back.load(std::memory_order_relaxed);
     size_t bmod = (b+1) & (size-1);
 #ifdef AL_DEBUG
@@ -79,7 +87,7 @@ public:
   }
 
   /** Return the next element in the queue; nullptr if empty. */
-  T pop() {
+  T pop() noexcept {
     size_t f = front.load(std::memory_order_relaxed);
     size_t b = back.load(std::memory_order_acquire);
     if (b == f) {
@@ -95,7 +103,11 @@ public:
    *
    * It is an error to call this if no element is present.
    */
-  void pop_always() {
+  void pop_always()
+#ifndef AL_DEBUG
+    noexcept
+#endif
+  {
     size_t f = front.load(std::memory_order_relaxed);
 #ifdef AL_DEBUG
     size_t b = back.load(std::memory_order_acquire);
@@ -107,7 +119,7 @@ public:
   }
 
   /** Return the next element in the queue; nullptr if empty. */
-  T peek() {
+  T peek() noexcept {
     size_t f = front.load(std::memory_order_relaxed);
     size_t b = back.load(std::memory_order_acquire);
     if (b == f) {

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -256,6 +256,13 @@ void ProgressEngine::enqueue(AlState* state) {
   // we always have to create it.
   const size_t locked_local_num_input_streams = local_num_input_streams;
 #endif
+#ifdef AL_DEBUG
+  // Ensure we do not try to use too many queues.
+  if (locked_local_num_input_streams >= AL_PE_NUM_STREAMS) {
+    throw_al_exception(
+      "Trying to create more progress engine streams than supported");
+  }
+#endif
   // Add the new queue.
   request_queues[locked_local_num_input_streams].compute_stream = state->get_compute_stream();
   ++num_input_streams;  // Make new queue visible.

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -390,9 +390,15 @@ void run_test(cxxopts::ParseResult& parsed_opts) {
 struct test_dispatcher {
   template <typename Backend, typename T>
   void operator()(cxxopts::ParseResult& parsed_opts) {
+    // Initialize the stream manager if necessary.
+    // Initialized here so we do it exactly once.
+    // Ensure there is one stream for every thread.
+    StreamManager<Backend>::init(
+      std::max(parsed_opts["threads"].as<int>(), 1));
     for (size_t i = 0; i < parsed_opts["trials"].as<size_t>(); ++i) {
       run_test<Backend, T>(parsed_opts);
     }
+    StreamManager<Backend>::finalize();
   }
 };
 

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -137,22 +137,27 @@ struct TestData {
            CommWrapper<Backend>& comm_wrapper) :
     input(VectorType<T, Backend>::gen_data(in_size, comm_wrapper.comm().get_stream())),
     output(VectorType<T, Backend>::gen_data(out_size, comm_wrapper.comm().get_stream())),
-    orig_input(input),
+    orig_input(output),
     mpi_input(VectorType<T, Backend>::copy_to_host(input)),
     mpi_output(VectorType<T, Backend>::copy_to_host(output)),
     orig_mpi_input(mpi_output)
   {}
 
-  void check(size_t size, bool inplace, bool dump_on_error,
-             size_t max_dump_size, CommWrapper<Backend>& comm_wrapper) {
+  void check(size_t size, bool inplace, bool dump_on_error, bool hang_on_error,
+             size_t max_dump_size, CommWrapper<Backend>& comm_wrapper,
+             int thread_id) {
     bool err = false;
     if (!inplace && !check_vector(mpi_input, input)) {
-      std::cerr << comm_wrapper.rank() << ": input does not match for size "
+      std::cerr << comm_wrapper.rank()
+                << " (thread " << thread_id << ")"
+                << ": input does not match for size "
                 << size << std::endl;
       err = true;
     }
     if (!check_vector(mpi_output, output)) {
-      std::cerr << comm_wrapper.rank() << ": output does not match for size "
+      std::cerr << comm_wrapper.rank()
+                << " (thread " << thread_id << ")"
+                << ": output does not match for size "
                 << size << std::endl;
       err = true;
     }
@@ -168,6 +173,9 @@ struct TestData {
           dump_data<Backend>(input, output, mpi_input, mpi_output,
                              comm_wrapper.comm());
         }
+      }
+      if (hang_on_error) {
+        hang_for_debugging(-1);  // Hang all ranks always.
       }
       std::abort();
     }
@@ -360,8 +368,9 @@ void run_test(cxxopts::ParseResult& parsed_opts) {
         }
         data[i].check(size, op_options.inplace,
                       parsed_opts.count("dump-on-error"),
+                      parsed_opts.count("hang-on-error"),
                       parsed_opts["max-dump-size"].as<size_t>(),
-                      comm_wrappers[i]);
+                      comm_wrappers[i], i);
       }
       MPI_Barrier(MPI_COMM_WORLD);
     }
@@ -381,7 +390,9 @@ void run_test(cxxopts::ParseResult& parsed_opts) {
 struct test_dispatcher {
   template <typename Backend, typename T>
   void operator()(cxxopts::ParseResult& parsed_opts) {
-    run_test<Backend, T>(parsed_opts);
+    for (size_t i = 0; i < parsed_opts["trials"].as<size_t>(); ++i) {
+      run_test<Backend, T>(parsed_opts);
+    }
   }
 };
 
@@ -407,6 +418,8 @@ int main(int argc, char** argv) {
     ("hang-rank", "Hang a specific or all ranks at startup", cxxopts::value<int>()->default_value("-1"))
     ("hang-timeout", "How long to wait for an operation to complete", cxxopts::value<size_t>()->default_value("60"))
     ("no-abort-on-hang", "Do not abort if a hang is detected")
+    ("hang-on-error", "Hang when an error is detected")
+    ("trials", "Number of times to run the test", cxxopts::value<size_t>()->default_value("1"))
     ("help", "Print help");
   auto parsed_opts = options.parse(argc, argv);
 

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -94,6 +94,24 @@ typename VectorType<T, Backend>::type get_vector(size_t count) {
   return typename VectorType<T, Backend>::type(count);
 }
 
+/**
+ * Manager for streams for a backend.
+ *
+ * Default implementation for backends that do not have real streams.
+ */
+template <typename Backend>
+struct StreamManager {
+  /** Type of the underlying stream. */
+  using StreamType = int;
+
+  /** Initialize the stream manager to support this many streams. */
+  static void init(size_t /*num_streams*/) {}
+  /** Clean up the stream manager. */
+  static void finalize() {}
+  /** Return a new stream. */
+  static StreamType get_stream() { return 0; };
+};
+
 /** RAII manager for a communicator. */
 template <typename Backend>
 struct CommWrapper {

--- a/test/test_utils_nccl.hpp
+++ b/test/test_utils_nccl.hpp
@@ -68,25 +68,33 @@ template <> struct VectorType<__half, Al::NCCLBackend> {
   }
 };
 
+// Specialize to use the Aluminum stream pool, and size it appropriately.
+template <>
+struct StreamManager<Al::NCCLBackend> {
+  using StreamType = cudaStream_t;
+
+  static void init(size_t num_streams) {
+    get_stream_pool().allocate(num_streams);
+  }
+  static void finalize() {
+    get_stream_pool().clear();
+  }
+  static StreamType get_stream() {
+    return get_stream_pool().get_stream();
+  }
+
+private:
+  static Al::internal::cuda::StreamPool& get_stream_pool() {
+   static Al::internal::cuda::StreamPool streams;
+   return streams;
+  }
+};
+
 // Specialize to create a CUDA stream with the communicator.
 template <>
 CommWrapper<Al::NCCLBackend>::CommWrapper(MPI_Comm mpi_comm) {
-  cudaStream_t stream;
-  AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamCreate(&stream));
   comm_ = std::make_unique<typename Al::NCCLBackend::comm_type>(
-    mpi_comm, stream);
-}
-template <>
-CommWrapper<Al::NCCLBackend>::~CommWrapper() {
-  if (comm_) {
-    try {
-      AL_FORCE_CHECK_CUDA_NOSYNC(cudaStreamDestroy(comm_->get_stream()));
-    } catch (const Al::al_exception &e) {
-      std::cerr << "Caught exception in CommWrapper<NCCLBackend> destructor: "
-                << e.what() << std::endl;
-      std::terminate();
-    }
-  }
+    mpi_comm, StreamManager<Al::NCCLBackend>::get_stream());
 }
 
 template <>


### PR DESCRIPTION
Previously when testing, each communicator instance (one per thread per test trial) would create a new compute stream. The progress engine has one input queue per compute stream, with a fixed number of such input queues decided at compile time. Thus, the host-transfer backend (and _only_ the host-transfer backend) could overflow the number of input queues.

This updates all backends to use a stream manager during testing. For MPI, this is essentially a NOP. For NCCL and host-transfer, this will use a dedicated stream pool with one stream per thread.

Also added some additional debugging checks. Closes #132.

Note this does *not* appear to fix #133.