### PR TITLE
Build system updates; warnings cleanup.

### DIFF
--- a/include/aluminum/base.hpp
+++ b/include/aluminum/base.hpp
@@ -39,6 +39,9 @@
 # endif
 #endif /* HOST_NAME_MAX */
 
+/** Intentionally ignore results of [[nodiscard]] functions. */
+#define AL_IGNORE_NODISCARD(fcall) static_cast<void>((fcall))
+
 namespace Al {
 
 /**

--- a/include/aluminum/cuda/cuda.hpp
+++ b/include/aluminum/cuda/cuda.hpp
@@ -99,8 +99,9 @@ inline hipError_t cuGetErrorString(hipError_t /* error */, const char** pStr)
     CUresult status_CHECK_CUDA_DRV = (cuda_call);               \
     if (status_CHECK_CUDA_DRV != CUDA_SUCCESS) {                \
       const char* err_msg_CHECK_CUDA_DRV;                       \
-      cuGetErrorString(status_CHECK_CUDA_DRV,                   \
-                       &err_msg_CHECK_CUDA_DRV);                \
+      AL_IGNORE_NODISCARD(                                      \
+        cuGetErrorString(status_CHECK_CUDA_DRV,                 \
+                         &err_msg_CHECK_CUDA_DRV));             \
       throw_al_exception(std::string("CUDA driver error: ")     \
                          + err_msg_CHECK_CUDA_DRV);             \
     }                                                           \
@@ -112,8 +113,9 @@ inline hipError_t cuGetErrorString(hipError_t /* error */, const char** pStr)
     CUresult status_CHECK_CUDA_DRV = (cuda_call);               \
     if (status_CHECK_CUDA_DRV != CUDA_SUCCESS) {                \
       const char* err_msg_CHECK_CUDA_DRV;                       \
-      cuGetErrorString(status_CHECK_CUDA_DRV,                   \
-                       &err_msg_CHECK_CUDA_DRV);                \
+      AL_IGNORE_NODISCARD(                                      \
+        cuGetErrorString(status_CHECK_CUDA_DRV,                 \
+                         &err_msg_CHECK_CUDA_DRV));             \
       throw_al_exception(std::string("CUDA driver error: ")     \
                          + err_msg_CHECK_CUDA_DRV);             \
     }                                                           \

--- a/include/aluminum/cuda/cuda_mempool.hpp
+++ b/include/aluminum/cuda/cuda_mempool.hpp
@@ -76,7 +76,7 @@ public:
     AL_CHECK_CUDA(cub_pool.DeviceFree(ptr));
   }
 
-  void clear() { cub_pool.FreeAllCached(); }
+  void clear() { AL_IGNORE_NODISCARD(cub_pool.FreeAllCached()); }
 
 private:
   cub::CachingDeviceAllocator cub_pool;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,8 @@ target_include_directories(Al PUBLIC
   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(Al PUBLIC
-  MPI::MPI_CXX HWLOC::hwloc
+  HWLOC::hwloc
+  MPI::MPI_CXX
   $<TARGET_NAME_IF_EXISTS:roc::rccl>
   $<TARGET_NAME_IF_EXISTS:hip::rocprim_hip>
   $<TARGET_NAME_IF_EXISTS:hip::hipcub>)


### PR DESCRIPTION
These should be no-op changes that just make some things move more smoothly when building.

The HWLOC issue comes up when certain MPI libraries have, say, exported HWLOC symbols into their `.so`s. Having the MPI library first in the link order means that it’s also first in the symbol search order, which means that asking for the HWLOC version, for example, might find the ancient version that the MPI library uesd instead of the newer `libhwloc` that a user built or that is present on the system. This simple change in the Al build system seems to resolve this issue.

The HIP headers declare many functions `[[nodiscard]]`, so if one doesn’t check EVERY return code, Clang might throw up a warning. However, there are a few cases in which we deliberately don't care about the return code (e.g., another error is about to be thrown, or the universe is shutting down). This PR just silences the warnings.