### PR TITLE
Initialize the stream pool in the benchmark driver

### DIFF
--- a/benchmark/benchmark_ops.cpp
+++ b/benchmark/benchmark_ops.cpp
@@ -63,6 +63,7 @@ void run_benchmark(cxxopts::ParseResult& parsed_opts) {
 
   auto sizes = get_sizes_from_opts(parsed_opts);
 
+  StreamManager<Backend>::init(1UL);
   CommWrapper<Backend> comm_wrapper(MPI_COMM_WORLD);
   OpProfile<Op, Backend, T> profile(comm_wrapper.comm(), op_options);
   Timer<Backend> timer;

--- a/benchmark/benchmark_ops.cpp
+++ b/benchmark/benchmark_ops.cpp
@@ -164,6 +164,8 @@ void run_benchmark(cxxopts::ParseResult& parsed_opts) {
   if (!parsed_opts.count("no-print-table")) {
     profile.print_results();
   }
+
+  StreamManager<Backend>::finalize();
 }
 
 template <AlOperation Op, typename Backend, typename T,


### PR DESCRIPTION
I was seeing an error where this was not done, so there was a "mod-by-zero" error on the following line (constructing the `CommWrapper`), specifically when using GPU-based backends.

Offline chat with @ndryden suggests that `1` is the correct value here, since, unlike `test_ops.cpp`, we do not want to use threads. Should that be incorrect or change, modifying this to match `test_ops.cpp` would not be difficult.