### PR TITLE
Ensure the hipified headers are generated properly

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ if (AL_HAS_ROCM)
   # files. This should circumvent that issue.
   add_custom_target(HipifiedHeaders
     DEPENDS ${ALUMINUM_HIP_HEADERS})
-  hip_add_library(Al "${ALUMINUM_HIP_SOURCES}" "${ALUMINUM_HIP_HEADERS}")
+  hip_add_library(Al "${ALUMINUM_HIP_SOURCES}")
   add_dependencies(Al HipifiedHeaders)
   target_include_directories(Al PUBLIC
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,13 @@ set(ALUMINUM_CUDA_SOURCES "${CUDA_SOURCES}" "${THIS_DIR_CUDA_SOURCES}")
 if (AL_HAS_ROCM)
   hipify_source_files(ALUMINUM_HIP_SOURCES ${ALUMINUM_CXX_SOURCES} ${ALUMINUM_CUDA_SOURCES})
   hipify_header_files(ALUMINUM_HIP_HEADERS ${ALUMINUM_HEADERS})
+  # Some generators seem to miss the memo about having to pre-generate
+  # all the headers before attempting to compile the source
+  # files. This should circumvent that issue.
+  add_custom_target(HipifiedHeaders
+    DEPENDS ${ALUMINUM_HIP_HEADERS})
   hip_add_library(Al "${ALUMINUM_HIP_SOURCES}" "${ALUMINUM_HIP_HEADERS}")
+  add_dependencies(Al HipifiedHeaders)
   target_include_directories(Al PUBLIC
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
 else ()


### PR DESCRIPTION
This avoids a sporadic bug in which the Makefile generator might not respect the generated header dependency properly. A user reported issues with using Makefiles wherein compilation units attempted to `#include` headers that had not been generated yet. By forcing them to be dependencies of a custom target that the main library target depends upon, this should ensure that the headers are always generated prior to compiling any other unit.