### PR TITLE
Fix `std::accumulate` calls

### DIFF
--- a/include/aluminum/ht/reduce_scatterv.hpp
+++ b/include/aluminum/ht/reduce_scatterv.hpp
@@ -43,7 +43,7 @@ public:
                        ReductionOperator op_, HostTransferCommunicator& comm_,
                        cudaStream_t stream_) :
     HostTransferCollectiveSignalAtEndState(stream_),
-    total_size(std::accumulate(counts_.begin(), counts_.end(), 0)),
+    total_size(std::accumulate(counts_.begin(), counts_.end(), size_t{0})),
     host_mem(mempool.allocate<MemoryType::CUDA_PINNED_HOST, T>(total_size)),
     counts(mpi::intify_size_t_vector(counts_)),
     op(mpi::ReductionOperator2MPI_Op(op_)),

--- a/include/aluminum/nccl_impl.hpp
+++ b/include/aluminum/nccl_impl.hpp
@@ -1065,7 +1065,7 @@ class NCCLBackend {
       // For simplicity, we will ensure it is contiguous.
       // TODO: Optimize this.
       size_t sendbuf_len = std::accumulate(send_counts.begin(),
-                                           send_counts.end(), 0);
+                                           send_counts.end(), size_t{0});
       std::vector<size_t> contig_displs = excl_prefix_sum(send_counts);
       tmp_sendbuf = internal::mempool.allocate<internal::MemoryType::CUDA, T>(
         sendbuf_len, stream);
@@ -1124,7 +1124,7 @@ class NCCLBackend {
                                  cudaStream_t stream) {
     // This is implemented as a reduce followed by a scatterv.
     // Rank 0 is the root.
-    size_t count = std::accumulate(counts.begin(), counts.end(), 0);
+    size_t count = std::accumulate(counts.begin(), counts.end(), size_t{0});
     std::vector<size_t> displs = excl_prefix_sum(counts);
     // Need a temporary reduce buffer so we don't trash the entire thing.
     T* tmp_redbuf = internal::mempool.allocate<internal::MemoryType::CUDA, T>(

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -110,7 +110,7 @@ std::vector<hwloc_bitmap_t> local_exchange_hwloc_bitmaps(
 
   // Collect all the bitmaps.
   size_t total_len = std::accumulate(bitmap_lens.begin(),
-                                     bitmap_lens.end(), 0);
+                                     bitmap_lens.end(), size_t{0});
   std::vector<unsigned long> gathered_bitmaps = std::vector<unsigned long>(total_len);
   // Compute displacements (TODO: Should generalize excl_prefix_sum).
   std::vector<int> displs = std::vector<int>(bitmap_lens.size(), 0);


### PR DESCRIPTION
Some calls to `std::accumulate` could overflow by accumulating `size_t`s into `int`s. This fixes them.

h/t @benson31 for pointing it out.