### PR TITLE
Prevent early exits

### DIFF
--- a/include/aluminum/ht_impl.hpp
+++ b/include/aluminum/ht_impl.hpp
@@ -130,7 +130,6 @@ class HostTransferBackend {
   static void Allreduce(const T* sendbuf, T* recvbuf, size_t count,
                         ReductionOperator op, comm_type& comm,
                         allreduce_algo_type algo) {
-    if (count == 0) return;
     switch (algo) {
     case HostTransferAllreduceAlgorithm::automatic:
     case HostTransferAllreduceAlgorithm::host_transfer:
@@ -154,7 +153,6 @@ class HostTransferBackend {
       comm_type& comm,
       req_type& req,
       allreduce_algo_type algo) {
-    if (count == 0) return;
     cudaStream_t internal_stream = internal::cuda::stream_pool.get_high_priority_stream();
     sync_internal_stream_with_comm(internal_stream, comm);
     switch (algo) {
@@ -228,7 +226,6 @@ class HostTransferBackend {
   static void Allgather(
     const T* sendbuf, T* recvbuf, size_t count,
     comm_type& comm, allgather_algo_type algo) {
-    if (count == 0) return;
     switch (algo) {
     case HostTransferCollectiveAlgorithm::automatic:
       do_allgather(sendbuf, recvbuf, count, comm, comm.get_stream());
@@ -248,7 +245,6 @@ class HostTransferBackend {
   static void NonblockingAllgather(
     const T* sendbuf, T* recvbuf, size_t count,
     comm_type& comm, req_type& req, allgather_algo_type algo) {
-    if (count == 0) return;
     cudaStream_t internal_stream = internal::cuda::stream_pool.get_high_priority_stream();
     sync_internal_stream_with_comm(internal_stream, comm);
     switch (algo) {
@@ -319,7 +315,6 @@ class HostTransferBackend {
   static void Alltoall(
     const T* sendbuf, T* recvbuf, size_t count,
     comm_type& comm, alltoall_algo_type algo) {
-    if (count == 0) return;
     switch (algo) {
     case HostTransferCollectiveAlgorithm::automatic:
       do_alltoall(sendbuf, recvbuf, count, comm, comm.get_stream());
@@ -339,7 +334,6 @@ class HostTransferBackend {
   static void NonblockingAlltoall(
     const T* sendbuf, T* recvbuf, size_t count,
     comm_type& comm, req_type& req, alltoall_algo_type algo) {
-    if (count == 0) return;
     cudaStream_t internal_stream = internal::cuda::stream_pool.get_high_priority_stream();
     sync_internal_stream_with_comm(internal_stream, comm);
     switch (algo) {
@@ -441,7 +435,6 @@ class HostTransferBackend {
   template <typename T>
   static void Bcast(T* buf, size_t count, int root, comm_type& comm,
                     bcast_algo_type algo) {
-    if (count == 0) return;
     switch (algo) {
     case HostTransferCollectiveAlgorithm::automatic:
       do_bcast(buf, count, root, comm, comm.get_stream());
@@ -455,7 +448,6 @@ class HostTransferBackend {
   static void NonblockingBcast(
     T* buf, size_t count, int root,
     comm_type& comm, req_type& req, bcast_algo_type algo) {
-    if (count == 0) return;
     cudaStream_t internal_stream = internal::cuda::stream_pool.get_high_priority_stream();
     sync_internal_stream_with_comm(internal_stream, comm);
     switch (algo) {
@@ -472,7 +464,6 @@ class HostTransferBackend {
   static void Gather(
     const T* sendbuf, T* recvbuf, size_t count, int root,
     comm_type& comm, gather_algo_type algo) {
-    if (count == 0) return;
     switch (algo) {
     case HostTransferCollectiveAlgorithm::automatic:
       do_gather(sendbuf, recvbuf, count, root, comm, comm.get_stream());
@@ -492,7 +483,6 @@ class HostTransferBackend {
   static void NonblockingGather(
     const T* sendbuf, T* recvbuf, size_t count, int root,
     comm_type& comm, req_type& req, gather_algo_type algo) {
-    if (count == 0) return;
     cudaStream_t internal_stream = internal::cuda::stream_pool.get_high_priority_stream();
     sync_internal_stream_with_comm(internal_stream, comm);
     switch (algo) {
@@ -561,7 +551,6 @@ class HostTransferBackend {
   static void Reduce(
     const T* sendbuf, T* recvbuf, size_t count, ReductionOperator op, int root,
     comm_type& comm, reduce_algo_type algo) {
-    if (count == 0) return;
     switch (algo) {
     case HostTransferCollectiveAlgorithm::automatic:
       do_reduce(sendbuf, recvbuf, count, op, root, comm, comm.get_stream());
@@ -582,7 +571,6 @@ class HostTransferBackend {
   static void NonblockingReduce(
     const T* sendbuf, T* recvbuf, size_t count, ReductionOperator op, int root,
     comm_type& comm, req_type& req, reduce_algo_type algo) {
-    if (count == 0) return;
     cudaStream_t internal_stream = internal::cuda::stream_pool.get_high_priority_stream();
     sync_internal_stream_with_comm(internal_stream, comm);
     switch (algo) {
@@ -606,7 +594,6 @@ class HostTransferBackend {
   static void Reduce_scatter(
     const T* sendbuf, T* recvbuf, size_t count, ReductionOperator op,
     comm_type& comm, reduce_scatter_algo_type algo) {
-    if (count == 0) return;
     switch (algo) {
     case HostTransferCollectiveAlgorithm::automatic:
       do_reduce_scatter(sendbuf, recvbuf, count, op, comm, comm.get_stream());
@@ -627,7 +614,6 @@ class HostTransferBackend {
   static void NonblockingReduce_scatter(
     const T* sendbuf, T* recvbuf, size_t count, ReductionOperator op,
     comm_type& comm, req_type& req, reduce_scatter_algo_type algo) {
-    if (count == 0) return;
     cudaStream_t internal_stream = internal::cuda::stream_pool.get_high_priority_stream();
     sync_internal_stream_with_comm(internal_stream, comm);
     switch (algo) {
@@ -694,7 +680,6 @@ class HostTransferBackend {
   static void Scatter(
     const T* sendbuf, T* recvbuf, size_t count, int root,
     comm_type& comm, scatter_algo_type algo) {
-    if (count == 0) return;
     switch (algo) {
     case HostTransferCollectiveAlgorithm::automatic:
       do_scatter(sendbuf, recvbuf, count, root, comm, comm.get_stream());
@@ -714,7 +699,6 @@ class HostTransferBackend {
   static void NonblockingScatter(
     const T* sendbuf, T* recvbuf, size_t count, int root,
     comm_type& comm, req_type& req, scatter_algo_type algo) {
-    if (count == 0) return;
     cudaStream_t internal_stream = internal::cuda::stream_pool.get_high_priority_stream();
     sync_internal_stream_with_comm(internal_stream, comm);
     switch (algo) {

--- a/include/aluminum/mpi_impl.hpp
+++ b/include/aluminum/mpi_impl.hpp
@@ -209,7 +209,6 @@ class MPIBackend {
   static void Allgather(
     const T* sendbuf, T* recvbuf, size_t count,
     comm_type& comm, allgather_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -232,7 +231,6 @@ class MPIBackend {
   static void NonblockingAllgather(
     const T* sendbuf, T* recvbuf, size_t count,
     comm_type& comm, req_type& req, allgather_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -310,7 +308,6 @@ class MPIBackend {
   static void Alltoall(
     const T* sendbuf, T* recvbuf, size_t count,
     comm_type& comm, alltoall_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -333,7 +330,6 @@ class MPIBackend {
   static void NonblockingAlltoall(
     const T* sendbuf, T* recvbuf, size_t count,
     comm_type& comm, req_type& req, alltoall_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -441,7 +437,6 @@ class MPIBackend {
   template <typename T>
   static void Bcast(T* buf, size_t count, int root, comm_type& comm,
                     bcast_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -458,7 +453,6 @@ class MPIBackend {
   static void NonblockingBcast(
     T* buf, size_t count, int root,
     comm_type& comm, req_type& req, bcast_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -474,7 +468,6 @@ class MPIBackend {
   static void Gather(
     const T* sendbuf, T* recvbuf, size_t count, int root,
     comm_type& comm, gather_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -497,7 +490,6 @@ class MPIBackend {
   static void NonblockingGather(
     const T* sendbuf, T* recvbuf, size_t count, int root,
     comm_type& comm, req_type& req, gather_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -575,7 +567,6 @@ class MPIBackend {
   static void Reduce(
     const T* sendbuf, T* recvbuf, size_t count, ReductionOperator op, int root,
     comm_type& comm, reduce_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -599,7 +590,6 @@ class MPIBackend {
   static void NonblockingReduce(
     const T* sendbuf, T* recvbuf, size_t count, ReductionOperator op, int root,
     comm_type& comm, req_type& req, reduce_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -622,7 +612,6 @@ class MPIBackend {
   static void Reduce_scatter(
     const T* sendbuf, T* recvbuf, size_t count, ReductionOperator op,
     comm_type& comm, reduce_scatter_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -646,7 +635,6 @@ class MPIBackend {
   static void NonblockingReduce_scatter(
     const T* sendbuf, T* recvbuf, size_t count, ReductionOperator op,
     comm_type& comm, req_type& req, reduce_scatter_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -723,7 +711,6 @@ class MPIBackend {
   static void Scatter(
     const T* sendbuf, T* recvbuf, size_t count, int root,
     comm_type& comm, scatter_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:
@@ -746,7 +733,6 @@ class MPIBackend {
   static void NonblockingScatter(
     const T* sendbuf, T* recvbuf, size_t count, int root,
     comm_type& comm, req_type& req, scatter_algo_type algo) {
-    if (count == 0) return;
     internal::mpi::assert_count_fits_mpi(count);
     switch (algo) {
     case MPICollectiveAlgorithm::automatic:

--- a/include/aluminum/nccl_impl.hpp
+++ b/include/aluminum/nccl_impl.hpp
@@ -805,9 +805,6 @@ class NCCLBackend {
   static void do_allreduce(const T* sendbuf, T* recvbuf, size_t count,
                            ReductionOperator op, comm_type& comm,
                            cudaStream_t stream) {
-    if (count == 0) {
-      return;
-    }
     if (sendbuf == internal::IN_PLACE<T>()) {
       sendbuf = recvbuf;
     }
@@ -821,9 +818,6 @@ class NCCLBackend {
   template <typename T>
   static void do_send(const T* sendbuf, size_t count, int dest, comm_type& comm,
                       cudaStream_t stream) {
-    if (count == 0) {
-      return;
-    }
     AL_CHECK_NCCL(ncclSend((const void*) sendbuf, count,
                            internal::nccl::TypeMap<T>(), dest,
                            comm.m_nccl_comm, stream));
@@ -833,9 +827,6 @@ class NCCLBackend {
   template <typename T>
   static void do_recv(T* recvbuf, size_t count, int src, comm_type& comm,
                       cudaStream_t stream) {
-    if (count == 0) {
-      return;
-    }
     AL_CHECK_NCCL(ncclRecv((void*) recvbuf, count,
                            internal::nccl::TypeMap<T>(), src,
                            comm.m_nccl_comm, stream));
@@ -846,21 +837,13 @@ class NCCLBackend {
   static void do_sendrecv(const T* sendbuf, size_t send_count, int dest,
                           T* recvbuf, size_t recv_count, int src,
                           comm_type& comm, cudaStream_t stream) {
-    if (send_count == 0 && recv_count == 0) {
-      return;
-    }
     AL_CHECK_NCCL(ncclGroupStart());
-    // Work around some sort of potential bug.
-    if (send_count != 0) {
-      AL_CHECK_NCCL(ncclSend((const void*) sendbuf, send_count,
-                             internal::nccl::TypeMap<T>(), dest,
-                             comm.m_nccl_comm, stream));
-    }
-    if (recv_count != 0) {
-      AL_CHECK_NCCL(ncclRecv((void*) recvbuf, recv_count,
-                             internal::nccl::TypeMap<T>(), src,
-                             comm.m_nccl_comm, stream));
-    }
+    AL_CHECK_NCCL(ncclSend((const void*) sendbuf, send_count,
+                           internal::nccl::TypeMap<T>(), dest,
+                           comm.m_nccl_comm, stream));
+    AL_CHECK_NCCL(ncclRecv((void*) recvbuf, recv_count,
+                           internal::nccl::TypeMap<T>(), src,
+                           comm.m_nccl_comm, stream));
     AL_CHECK_NCCL(ncclGroupEnd());
   }
 
@@ -881,9 +864,6 @@ class NCCLBackend {
   template <typename T>
   static void do_broadcast(T* buf, size_t count, int root, comm_type& comm,
                            cudaStream_t stream) {
-    if (count == 0) {
-      return;
-    }
     AL_CHECK_NCCL(ncclBroadcast((const void*) buf, (void*) buf, count,
                                 internal::nccl::TypeMap<T>(), root,
                                 comm.m_nccl_comm, stream));
@@ -893,9 +873,6 @@ class NCCLBackend {
   template <typename T>
   static void do_gather(const T* sendbuf, T* recvbuf, size_t count, int root,
                         comm_type& comm, cudaStream_t stream) {
-    if (count == 0) {
-      return;
-    }
     if (sendbuf == internal::IN_PLACE<T>()) {
       if (comm.rank() == root) {
         sendbuf = recvbuf + comm.rank() * count;
@@ -968,9 +945,6 @@ class NCCLBackend {
   static void do_reduce(const T* sendbuf, T* recvbuf, size_t count,
                         ReductionOperator op, int root, comm_type& comm,
                         cudaStream_t stream) {
-    if (count == 0) {
-      return;
-    }
     if (sendbuf == internal::IN_PLACE<T>()) {
       sendbuf = recvbuf;
     }
@@ -984,9 +958,6 @@ class NCCLBackend {
   template <typename T>
   static void do_allgather(const T* sendbuf, T* recvbuf, size_t send_count,
                            comm_type& comm, cudaStream_t stream) {
-    if (send_count == 0) {
-      return;
-    }
     if (sendbuf == internal::IN_PLACE<T>()) {
       sendbuf = recvbuf + comm.rank()*send_count;
     }
@@ -1021,9 +992,6 @@ class NCCLBackend {
   template <typename T>
   static void do_alltoall(const T* sendbuf, T* recvbuf, size_t count,
                           comm_type& comm, cudaStream_t stream) {
-    if (count == 0) {
-      return;
-    }
     if (sendbuf == internal::IN_PLACE<T>()) {
       sendbuf = recvbuf;
     }
@@ -1103,9 +1071,6 @@ class NCCLBackend {
   static void do_reduce_scatter(const T* sendbuf, T* recvbuf,
                                 size_t recv_count, ReductionOperator op,
                                 comm_type& comm, cudaStream_t stream) {
-    if (recv_count == 0) {
-      return;
-    }
     if (sendbuf == internal::IN_PLACE<T>()) {
       sendbuf = recvbuf;
     }
@@ -1143,9 +1108,6 @@ class NCCLBackend {
   template <typename T>
   static void do_scatter(const T* sendbuf, T* recvbuf, size_t count, int root,
                          comm_type& comm, cudaStream_t stream) {
-    if (count == 0) {
-      return;
-    }
     if (sendbuf == internal::IN_PLACE<T>() && comm.rank() == root) {
       sendbuf = recvbuf;
       recvbuf = recvbuf + comm.rank()*count;


### PR DESCRIPTION
Depends on #145.

The MPI standard explicitly allows zero-length messages (Section 3.2.2 "`count` may be zero"), which serve as synchronization.

We had previously introduced an "early exit" in a number of functions, where when the count was 0, we would do no communication. Obviously, this prevents the synchronization.

Here, we remove those checks and allow zero-length operations across all backends. If a user desires to avoid them, they can add a check in their code.

There was also a note in the NCCL sendrecv code about avoiding zero-length messages because of a potential bug. This does not appear to be an issue presently (at least in my testing on Lassen using NCCL 2.12.10-1).