### PR TITLE
Fix a variety of build issues with ROCm 5

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -38,6 +38,11 @@ foreach(src ${AL_BENCHMARK_SOURCES})
   if (AL_HAS_CUDA AND NOT AL_HAS_ROCM)
     target_link_libraries(${_benchmark_exe_name} PUBLIC cuda)
   endif ()
+
+  # FIXME: Hopefully this can be removed in a future version of ROCm.
+  if (AL_HAS_ROCM AND AL_BUILD_TYPE_UPPER MATCHES "DEBUG")
+    target_compile_options(${_benchmark_exe_name} PRIVATE "-O0")
+  endif ()
 endforeach()
 
 # Do it all again for "special" benchmarks...
@@ -92,5 +97,10 @@ foreach(src ${AL_SPECIAL_BENCHMARK_SOURCES})
 
   if (AL_HAS_CUDA AND NOT AL_HAS_ROCM)
     target_link_libraries(${_benchmark_exe_name} PRIVATE cuda)
+  endif ()
+
+  # FIXME: Hopefully this can be removed in a future version of ROCm.
+  if (AL_HAS_ROCM AND AL_BUILD_TYPE_UPPER MATCHES "DEBUG")
+    target_compile_options(${_benchmark_exe_name} PRIVATE "-O0")
   endif ()
 endforeach ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,47 @@ target_link_libraries(Al PUBLIC
   MPI::MPI_CXX)
 
 if (AL_HAS_ROCM)
+  set(HIP_CLANG_ROOT "${AL_ROCM_PATH}/llvm")
+
+  ##############################
+  # FIXME: This bit is to fix errors in the HIP CMake config
+  # file. Hopefully this can be removed in a future version of ROCm.
+  file(GLOB HIP_CLANG_INCLUDE_SEARCH_PATHS
+    "${HIP_CLANG_ROOT}/lib/clang/*/include")
+  find_path(HIP_CLANG_INCLUDE_PATH stddef.h
+    HINTS "${HIP_CLANG_INCLUDE_SEARCH_PATHS}"
+    NO_DEFAULT_PATH)
+
+  file(GLOB HIP_CLANGRT_LIB_SEARCH_PATHS
+    "${HIP_CLANG_ROOT}/lib/clang/*/lib/*")
+  find_library(ACTUAL_CLANGRT_BUILTINS clangrt-builtins
+    NAMES
+    clang_rt.builtins
+    clang_rt.builtins-x86_64
+    PATHS
+    "${HIP_CLANGRT_LIB_SEARCH_PATHS}")
+
+  get_target_property(_HIP_HOST_LIBS hip::host INTERFACE_LINK_LIBRARIES)
+  get_target_property(_HIP_DEVICE_LIBS hip::device INTERFACE_LINK_LIBRARIES)
+
+  string(REPLACE
+    "CLANGRT_BUILTINS-NOTFOUND"
+    "${ACTUAL_CLANGRT_BUILTINS}"
+    _NEW_HIP_HOST_LIBS
+    "${_HIP_HOST_LIBS}")
+  string(REPLACE
+    "CLANGRT_BUILTINS-NOTFOUND"
+    "${ACTUAL_CLANGRT_BUILTINS}"
+    _NEW_HIP_DEVICE_LIBS
+    "${_HIP_DEVICE_LIBS}")
+
+  set_property(TARGET hip::host
+    PROPERTY INTERFACE_LINK_LIBRARIES ${_NEW_HIP_HOST_LIBS})
+  set_property(TARGET hip::device
+    PROPERTY INTERFACE_LINK_LIBRARIES ${_NEW_HIP_DEVICE_LIBS})
+  # END FIXME BLOCK
+  ##############################
+
   target_include_directories(Al PRIVATE
     $<BUILD_INTERFACE:${ROCM_SMI_INCLUDE_DIR}>)
   target_link_libraries(Al PUBLIC
@@ -82,7 +123,8 @@ if (AL_HAS_ROCM)
     roc::rccl
     hip::hipcub
     roc::rocprim
-    ${ROCM_SMI_LIBRARY})
+    ${ROCM_SMI_LIBRARY}
+    Threads::Threads)
 elseif (AL_HAS_CUDA)
   target_link_libraries(Al PUBLIC
     CUDA::cudart

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,11 @@ if (AL_ENABLE_TESTS)
       target_link_libraries(${_test_exe_name} PUBLIC cuda)
     endif()
     target_link_libraries(${_test_exe_name} PRIVATE Threads::Threads)
+
+    # FIXME: Hopefully this can be removed in a future version of ROCm.
+    if (AL_HAS_ROCM AND AL_BUILD_TYPE_UPPER MATCHES "DEBUG")
+      target_compile_options(${_test_exe_name} PRIVATE "-O0")
+    endif ()
   endforeach()
 
   # FIXME: Should any of these tests be enabled with ROCm?
@@ -89,5 +94,11 @@ if (AL_ENABLE_TESTS)
     target_link_libraries(test_rma_halo_exchange.exe PRIVATE Al)
     target_link_libraries(test_rma_halo_exchange.exe PUBLIC cuda)
     target_link_libraries(${_test_exe_name} PRIVATE Threads::Threads)
+  endif ()
+
+  if (AL_HAS_ROCM AND AL_BUILD_TYPE_UPPER MATCHES "DEBUG")
+    set_source_files_properties(
+      ${AL_TEST_SOURCES}
+      COMPILE_OPTIONS "-O0")
   endif ()
 endif ()


### PR DESCRIPTION
There are two issues in play here.

First, there seems to be an issue with finding the ROCm clang builtins and include paths. So we just find them and replace any "NOTFOUND" values in the relevant targets.

Second, the benchmarks and tests take approximately 1 hour per enabled backend when compiling with ANY optimization level more than "-O0". So we force that for the benchmarks when building in "DEBUG" mode. Release builds are unaffected, and the Aluminum library will be compiled with "-Og" still.