### PR TITLE
Cleanup some loose ends when building without RCCL.

### DIFF
--- a/include/aluminum/ht/reduce_scatterv.hpp
+++ b/include/aluminum/ht/reduce_scatterv.hpp
@@ -31,6 +31,8 @@
 #include "aluminum/ht/communicator.hpp"
 #include "aluminum/ht/base_state.hpp"
 
+#include <numeric> // std::accumulate
+
 namespace Al {
 namespace internal {
 namespace ht {

--- a/include/aluminum/ht_impl.hpp
+++ b/include/aluminum/ht_impl.hpp
@@ -37,6 +37,7 @@
 #include "aluminum/cuda/cuda.hpp"
 #include "aluminum/cuda/events.hpp"
 #include "aluminum/cuda/streams.hpp"
+#include "aluminum/mempool.hpp"
 #include "aluminum/progress.hpp"
 
 // IWYU pragma: begin_exports

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,12 +116,17 @@ if (AL_HAS_ROCM)
   # END FIXME BLOCK
   ##############################
 
+  if (AL_HAS_NCCL)
+    set(AL_NCCL_LIBRARY roc::rccl)
+  else ()
+    set(AL_NCCL_LIBRARY)
+  endif ()
   target_include_directories(Al PRIVATE
     $<BUILD_INTERFACE:${ROCM_SMI_INCLUDE_DIR}>)
   target_link_libraries(Al PUBLIC
     hip::host
-    roc::rccl
     hip::hipcub
+    ${AL_NCCL_LIBRARY}
     roc::rocprim
     ${ROCM_SMI_LIBRARY}
     ${Roctracer_LIBRARIES}


### PR DESCRIPTION
The mempool gets included with NCCL, but not without it.

The reduce-scatterv implementation uses the `<numeric>` header, which was missing.

The `roc::rccl` library was being added to the linkage even when RCCL hadn't been found.

These are all fixed and I'm able to build the library. Because it takes many, many minutes, I haven't tried building the tests/benchmarks.