### PR TITLE
HIP/ROCm stream memory operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ endif ()
 # Set -Og for debug builds when supported.
 check_cxx_compiler_flag("-Og" CXX_COMPILER_HAS_OG)
 if (CXX_COMPILER_HAS_OG)
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og -gdwarf-4")
 endif ()
 
 if (NOT DEFINED BUILD_SHARED_LIBS)

--- a/src/cuda/cuda.cpp
+++ b/src/cuda/cuda.cpp
@@ -52,17 +52,18 @@ bool stream_mem_ops_supported = false;
 void init(int&, char**&) {
   // Initialize internal streams.
   stream_pool.allocate(AL_CUDA_STREAM_POOL_SIZE);
-#ifndef AL_HAS_ROCM
   // Check whether stream memory operations are supported.
   CUdevice dev;
   AL_CHECK_CUDA_DRV(cuCtxGetDevice(&dev));
   int attr;
+#ifdef AL_HAS_ROCM
+  AL_CHECK_CUDA_DRV(hipDeviceGetAttribute(
+                      &attr, hipDeviceAttributeCanUseStreamWaitValue, dev));
+#else
   AL_CHECK_CUDA_DRV(cuDeviceGetAttribute(
                       &attr, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS, dev));
-  stream_mem_ops_supported = attr;
-#else
-  stream_mem_ops_supported = false;
 #endif
+  stream_mem_ops_supported = attr;
   // Preallocate memory for synchronization operations.
   sync_pool.preallocate(AL_SYNC_MEM_PREALLOC);
 }

--- a/src/cuda/helper_kernels.cu
+++ b/src/cuda/helper_kernels.cu
@@ -45,12 +45,15 @@ void launch_wait_kernel(cudaStream_t stream, int32_t wait_value, volatile int32_
   spin_wait_kernel<<<1,1,0,stream>>>(wait_value, wait_mem);
 }
 
-#if defined AL_HAS_CUDA && !defined AL_HAS_ROCM
 void launch_wait_kernel(cudaStream_t stream, int32_t wait_value, CUdeviceptr wait_mem) {
+#ifdef AL_HAS_ROCM
+  AL_CHECK_CUDA_DRV(hipStreamWaitValue32(
+                      stream, wait_mem, wait_value, hipStreamWaitValueEq));
+#else
   AL_CHECK_CUDA_DRV(cuStreamWaitValue32(
                       stream, wait_mem, wait_value, CU_STREAM_WAIT_VALUE_EQ));
+#endif
 }
-#endif // defined AL_HAS_CUDA && !defined AL_HAS_ROCM
 
 } // namespace cuda
 } // namespace internal


### PR DESCRIPTION
Uses stream memory operations when available on HIP/ROCm.

Note hipify (at least, when last I checked) did not pick work on these ops, hence the separate code paths.

Closes #156.