### PR TITLE
ROCm-friendly example codes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,4 +486,5 @@ install(FILES
 install(FILES
   cmake/FindHWLOC.cmake
   cmake/FindNCCL.cmake
+  cmake/FindRoctracer.cmake
   DESTINATION ${CMAKE_INSTALL_DIR})

--- a/examples/allreduce.cpp
+++ b/examples/allreduce.cpp
@@ -49,10 +49,10 @@ constexpr size_t num_elements = 4;
 // e.g., for GPUs, communication will be synchronized with respect to
 // that backend, and *not* the calling host code.
 //
-// Hence, for a CUDA-aware backend (NCCL, HostTransfer), Aluminum
-// operations follow standard CUDA semantics, and the host-side call
-// will complete after the operation has been enqueued. It is up to
-// you to ensure appropriate synchronization.
+// Hence, for a GPU-aware backend (NCCL, HostTransfer), Aluminum
+// operations follow standard CUDA/ROCm semantics, and the host-side
+// call will complete after the operation has been enqueued. It is up
+// to you to ensure appropriate synchronization.
 //
 // The MPI backend does not strictly have any streams associated with
 // it, but you can think of it as having a default stream which is the
@@ -61,7 +61,7 @@ constexpr size_t num_elements = 4;
 
 int main(int argc, char** argv) {
   // Initialize Aluminum.
-#ifdef AL_HAS_CUDA
+#if defined AL_HAS_CUDA || defined AL_HAS_ROCM
   const int num_gpus = get_number_of_gpus();
   const int local_rank = get_local_rank();
   const int local_size = get_local_size();
@@ -71,8 +71,8 @@ int main(int argc, char** argv) {
               << "(" << local_size << ")" << std::endl;
     std::abort();
   }
-  AL_FORCE_CHECK_CUDA_NOSYNC(cudaSetDevice(local_rank));
-#endif  /** AL_HAS_CUDA */
+  AL_FORCE_CHECK_GPU_NOSYNC(AlGpuSetDevice(local_rank));
+#endif  /** AL_HAS_CUDA || AL_HAS_ROCM */
   Al::Initialize(argc, argv);
 
   // Create our communicator.

--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -61,9 +61,10 @@ using AlBackend = Al::MPIBackend;
 
 
 int main(int argc, char** argv) {
-  // If using CUDA, you should set the CUDA device before initializing
-  // Aluminum. Aluminum expects there to be only one process per GPU.
-#ifdef AL_HAS_CUDA
+  // If using CUDA/HIP, you should set the CUDA/HIP device before
+  // initializing Aluminum. Aluminum expects there to be only one
+  // process per GPU.
+#if defined AL_HAS_CUDA || defined AL_HAS_ROCM
   // This simply uses cudaGetDeviceCount to determine the number of
   // GPUs. For testing, you can override that with the AL_NUM_GPUS
   // environment variable.
@@ -84,16 +85,16 @@ int main(int argc, char** argv) {
   }
 
   // Set the CUDA device.
-  // AL_FORCE_CHECK_CUDA_NOSYNC checks for CUDA errors and throws an
+  // AL_FORCE_CHECK_GPU_NOSYNC checks for CUDA errors and throws an
   // Aluminum exception if one occurs.
   // The "FORCE" means that the return value is always checked,
   // regardless of debug level.
-  // The "NOSYNC" means that the check does not synchronize the CUDA
-  // device beforehand, so it might also see errors from earlier CUDA
-  // calls.
-  // For general use, AL_CHECK_CUDA is probably the right choice.
-  AL_FORCE_CHECK_CUDA_NOSYNC(cudaSetDevice(local_rank));
-#endif  /** AL_HAS_CUDA */
+  // The "NOSYNC" means that the check does not synchronize the
+  // CUDA/HIP device beforehand, so it might also see errors from
+  // earlier CUDA/HIP calls.
+  // For general use, AL_CHECK_GPU is probably the right choice.
+  AL_FORCE_CHECK_GPU_NOSYNC(AlGpuSetDevice(local_rank));
+#endif  /** AL_HAS_CUDA || AL_HAS_ROCM */
 
   // Initialize Aluminum. Much like MPI, Aluminum takes argc and argv
   // as input. (Unlike MPI, it takes them by reference.)

--- a/examples/pingpong.cpp
+++ b/examples/pingpong.cpp
@@ -46,7 +46,7 @@ constexpr size_t num_iters = 4;
 
 int main(int argc, char** argv) {
   // Initialize Aluminum.
-#ifdef AL_HAS_CUDA
+#if defined AL_HAS_CUDA || defined AL_HAS_ROCM
   const int num_gpus = get_number_of_gpus();
   const int local_rank = get_local_rank();
   const int local_size = get_local_size();
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
               << "(" << local_size << ")" << std::endl;
     std::abort();
   }
-  AL_FORCE_CHECK_CUDA_NOSYNC(cudaSetDevice(local_rank));
+  AL_FORCE_CHECK_GPU_NOSYNC(AlGpuSetDevice(local_rank));
 #endif /** AL_HAS_CUDA */
   Al::Initialize(argc, argv);
 


### PR DESCRIPTION
The `examples/` directory was excluded from #163. (It also didn't use the `hipify` code, so it wouldn't have compiled under ROCm anyway.) I have updated it to the new `AlGpu` paradigm for hiding the GPU runtime at the source level. It compiles for me.