### PR TITLE
Defer starting the progress engine

### DIFF
--- a/include/aluminum/progress.hpp
+++ b/include/aluminum/progress.hpp
@@ -101,6 +101,10 @@ class ProgressEngine {
   std::condition_variable startup_cv;
   /** Atomic flag indicating that the progress engine has completed startup. */
   std::atomic<bool> started_flag;
+#ifdef AL_PE_START_ON_DEMAND
+  /** Atomic flag indicating that a thread is starting the progess engine. */
+  std::atomic<bool> doing_start_flag;
+#endif
   /**
    * Per-stream request queues.
    *

--- a/include/aluminum/tuning_params.hpp
+++ b/include/aluminum/tuning_params.hpp
@@ -58,6 +58,14 @@
  */
 // #define AL_PE_STREAM_QUEUE_CACHE 1
 
+/**
+ * Whether to delay starting the progress engine until it is actually
+ * needed. This results in a one-time penalty on the first call to an
+ * operation that uses the progress engine, but only a quick check
+ * thereafter.
+ */
+#define AL_PE_START_ON_DEMAND 1
+
 /** Amount of sync object memory to preallocate in the pool. */
 #define AL_SYNC_MEM_PREALLOC 1024
 

--- a/src/Al.cpp
+++ b/src/Al.cpp
@@ -120,7 +120,9 @@ void Initialize(int& argc, char**& argv) {
   }
   internal::mpi::init(argc, argv);
   progress_engine = new internal::ProgressEngine();
+#ifndef AL_PE_START_ON_DEMAND
   progress_engine->run();
+#endif
   is_initialized = true;
 #ifdef AL_HAS_CUDA
   internal::cuda::init(argc, argv);


### PR DESCRIPTION
(Depends on #165.)

This adds an option to delay starting the progress engine until it is needed. When enabled, this will increase the latency for the first use of the progress engine, and adds a tiny overhead for checking whether the progress engine has actually been started. When not using the progress engine (e.g., when only using NCCL or blocking MPI calls), this means we don't start the progress engine and can avoid it spinning or otherwise interfering with things.

This setting has been made the default.

Closes #118.