### PR TITLE
Support half with MPI

### DIFF
--- a/include/aluminum/CMakeLists.txt
+++ b/include/aluminum/CMakeLists.txt
@@ -1,11 +1,12 @@
 set_source_path(THIS_DIR_HEADERS
-  internal.hpp
-  progress.hpp
   base.hpp
+  datatypes.hpp
+  internal.hpp
   mempool.hpp
   mpi_comm_and_stream_wrapper.hpp
   mpi_impl.hpp
   profiling.hpp
+  progress.hpp
   state.hpp
   trace.hpp
   tuning_params.hpp

--- a/include/aluminum/cuda/cuda.hpp
+++ b/include/aluminum/cuda/cuda.hpp
@@ -35,12 +35,12 @@
 
 #if defined AL_HAS_ROCM
 #include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
 #elif defined AL_HAS_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <cuda_fp16.h>
 #endif
+
+#include "aluminum/datatypes.hpp"
 
 #ifdef AL_HAS_ROCM
 // HIP has no equivalent for the driver version of this.

--- a/include/aluminum/ht/allreduce.hpp
+++ b/include/aluminum/ht/allreduce.hpp
@@ -44,7 +44,7 @@ class AllreduceAlState : public HostTransferCollectiveSignalAtEndState {
     HostTransferCollectiveSignalAtEndState(stream_),
     host_mem(mempool.allocate<MemoryType::CUDA_PINNED_HOST, T>(count_)),
     count(count_),
-    op(mpi::ReductionOperator2MPI_Op(op_)),
+    op(mpi::ReductionOperator2MPI_Op<T>(op_)),
     comm(comm_.get_comm()) {
     // Transfer data from device to host.
     if (sendbuf != recvbuf) {

--- a/include/aluminum/ht/reduce.hpp
+++ b/include/aluminum/ht/reduce.hpp
@@ -44,7 +44,7 @@ public:
     host_mem(mempool.allocate<MemoryType::CUDA_PINNED_HOST, T>(count_)),
     count(count_),
     root(root_),
-    op(mpi::ReductionOperator2MPI_Op(op_)),
+    op(mpi::ReductionOperator2MPI_Op<T>(op_)),
     comm(comm_.get_comm()) {
     // Transfer data from device to host.
     AL_CHECK_CUDA(AlGpuMemcpyAsync(host_mem, sendbuf, sizeof(T)*count,

--- a/include/aluminum/ht/reduce_scatter.hpp
+++ b/include/aluminum/ht/reduce_scatter.hpp
@@ -44,7 +44,7 @@ public:
     HostTransferCollectiveSignalAtEndState(stream_),
     host_mem(mempool.allocate<MemoryType::CUDA_PINNED_HOST, T>(comm_.size()*count_)),
     count(count_),
-    op(mpi::ReductionOperator2MPI_Op(op_)),
+    op(mpi::ReductionOperator2MPI_Op<T>(op_)),
     comm(comm_.get_comm()) {
     // Transfer data from device to host.
     AL_CHECK_CUDA(AlGpuMemcpyAsync(host_mem, sendbuf, sizeof(T)*count*comm_.size(),

--- a/include/aluminum/ht/reduce_scatterv.hpp
+++ b/include/aluminum/ht/reduce_scatterv.hpp
@@ -48,7 +48,7 @@ public:
     total_size(std::accumulate(counts_.begin(), counts_.end(), size_t{0})),
     host_mem(mempool.allocate<MemoryType::CUDA_PINNED_HOST, T>(total_size)),
     counts(mpi::intify_size_t_vector(counts_)),
-    op(mpi::ReductionOperator2MPI_Op(op_)),
+    op(mpi::ReductionOperator2MPI_Op<T>(op_)),
     comm(comm_.get_comm()) {
     // Transfer data from device to host.
     AL_CHECK_CUDA(AlGpuMemcpyAsync(host_mem, sendbuf, sizeof(T)*total_size,

--- a/include/aluminum/mpi/allreduce.hpp
+++ b/include/aluminum/mpi/allreduce.hpp
@@ -40,7 +40,7 @@ template <typename T>
 void passthrough_allreduce(const T* sendbuf, T* recvbuf, size_t count,
                            ReductionOperator op, MPICommunicator& comm) {
   MPI_Allreduce(buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(),
-                ReductionOperator2MPI_Op(op), comm.get_comm());
+                ReductionOperator2MPI_Op<T>(op), comm.get_comm());
 }
 
 template <typename T>
@@ -50,7 +50,7 @@ public:
                    ReductionOperator op_, MPICommunicator& comm_, AlMPIReq req_) :
     MPIState(req_),
     sendbuf(sendbuf_), recvbuf(recvbuf_), count(count_),
-    op(ReductionOperator2MPI_Op(op_)), comm(comm_.get_comm()) {}
+    op(ReductionOperator2MPI_Op<T>(op_)), comm(comm_.get_comm()) {}
 
   ~AllreduceAlState() override {}
 

--- a/include/aluminum/mpi/reduce.hpp
+++ b/include/aluminum/mpi/reduce.hpp
@@ -44,7 +44,7 @@ void passthrough_reduce(const T* sendbuf, T* recvbuf, size_t count,
     sendbuf = recvbuf;
   }
   MPI_Reduce(buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(),
-             ReductionOperator2MPI_Op(op), root, comm.get_comm());
+             ReductionOperator2MPI_Op<T>(op), root, comm.get_comm());
 }
 
 template <typename T>
@@ -54,7 +54,7 @@ public:
                 int root_, MPICommunicator& comm_, AlMPIReq req_) :
     MPIState(req_),
     sendbuf(sendbuf_), recvbuf(recvbuf_), count(count_),
-    op(ReductionOperator2MPI_Op(op_)), root(root_),
+    op(ReductionOperator2MPI_Op<T>(op_)), root(root_),
     comm(comm_.get_comm()), rank(comm_.rank()) {}
 
   ~ReduceAlState() override {}

--- a/include/aluminum/mpi/reduce_scatter.hpp
+++ b/include/aluminum/mpi/reduce_scatter.hpp
@@ -40,7 +40,7 @@ template <typename T>
 void passthrough_reduce_scatter(const T* sendbuf, T* recvbuf, size_t count,
                                 ReductionOperator op, MPICommunicator& comm) {
   MPI_Reduce_scatter_block(buf_or_inplace(sendbuf), recvbuf, count,
-                           TypeMap<T>(), ReductionOperator2MPI_Op(op),
+                           TypeMap<T>(), ReductionOperator2MPI_Op<T>(op),
                            comm.get_comm());
 }
 
@@ -52,7 +52,7 @@ public:
                        AlMPIReq req_) :
     MPIState(req_),
     sendbuf(sendbuf_), recvbuf(recvbuf_), count(count_),
-    op(ReductionOperator2MPI_Op(op_)),
+    op(ReductionOperator2MPI_Op<T>(op_)),
     comm(comm_.get_comm()) {}
 
   ~ReduceScatterAlState() override {}

--- a/include/aluminum/mpi/reduce_scatterv.hpp
+++ b/include/aluminum/mpi/reduce_scatterv.hpp
@@ -44,7 +44,7 @@ void passthrough_reduce_scatterv(const T* sendbuf, T* recvbuf,
   std::vector<int> counts_ = intify_size_t_vector(counts);
   MPI_Reduce_scatter(buf_or_inplace(sendbuf), recvbuf,
                      counts_.data(), TypeMap<T>(),
-                     ReductionOperator2MPI_Op(op), comm.get_comm());
+                     ReductionOperator2MPI_Op<T>(op), comm.get_comm());
 }
 
 template <typename T>
@@ -57,7 +57,7 @@ public:
     MPIState(req_),
     sendbuf(sendbuf_), recvbuf(recvbuf_),
     counts(intify_size_t_vector(counts_)),
-    op(ReductionOperator2MPI_Op(op_)),
+    op(ReductionOperator2MPI_Op<T>(op_)),
     comm(comm_.get_comm()) {}
 
   ~ReduceScattervAlState() override {}

--- a/src/mpi_impl.cpp
+++ b/src/mpi_impl.cpp
@@ -34,11 +34,62 @@ namespace Al {
 namespace internal {
 namespace mpi {
 
+#ifdef AL_HAS_HALF
+// Reduction operators for half.
+MPI_Op half_sum_op;
+MPI_Op half_prod_op;
+MPI_Op half_min_op;
+MPI_Op half_max_op;
+#endif
+
 namespace {
 // Whether we initialized MPI, or it was already initialized.
 bool initialized_mpi = false;
 // Maximum tag value in MPI.
 int max_tag = 0;
+
+#ifdef AL_HAS_HALF
+// Operator implementations for half.
+void half_sum_reduction(void* invec_, void* inoutvec_, int* len,
+                        MPI_Datatype*) {
+  const __half* invec = reinterpret_cast<const __half*>(invec_);
+  __half* inoutvec = reinterpret_cast<__half*>(inoutvec_);
+  for (int i = 0; i < *len; ++i) {
+    inoutvec[i] = __float2half(
+      __half2float(invec[i]) + __half2float(inoutvec[i]));
+  }
+}
+
+void half_prod_reduction(void* invec_, void* inoutvec_, int* len,
+                        MPI_Datatype*) {
+  const __half* invec = reinterpret_cast<const __half*>(invec_);
+  __half* inoutvec = reinterpret_cast<__half*>(inoutvec_);
+  for (int i = 0; i < *len; ++i) {
+    inoutvec[i] = __float2half(
+      __half2float(invec[i]) * __half2float(inoutvec[i]));
+  }
+}
+
+void half_min_reduction(void* invec_, void* inoutvec_, int* len,
+                        MPI_Datatype*) {
+  const __half* invec = reinterpret_cast<const __half*>(invec_);
+  __half* inoutvec = reinterpret_cast<__half*>(inoutvec_);
+  for (int i = 0; i < *len; ++i) {
+    inoutvec[i] = __float2half(
+      std::min(__half2float(invec[i]), __half2float(inoutvec[i])));
+  }
+}
+
+void half_max_reduction(void* invec_, void* inoutvec_, int* len,
+                        MPI_Datatype*) {
+  const __half* invec = reinterpret_cast<const __half*>(invec_);
+  __half* inoutvec = reinterpret_cast<__half*>(inoutvec_);
+  for (int i = 0; i < *len; ++i) {
+    inoutvec[i] = __float2half(
+      std::max(__half2float(invec[i]), __half2float(inoutvec[i])));
+  }
+}
+#endif
 }
 
 void init(int& argc, char**& argv) {
@@ -69,6 +120,14 @@ void init(int& argc, char**& argv) {
   int* p;
   MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, &p, &flag);
   max_tag = *p;
+
+#ifdef AL_HAS_HALF
+  // Set up reduction operators for half.
+  MPI_Op_create(&half_sum_reduction, true, &half_sum_op);
+  MPI_Op_create(&half_prod_reduction, true, &half_prod_op);
+  MPI_Op_create(&half_min_reduction, true, &half_min_op);
+  MPI_Op_create(&half_max_reduction, true, &half_max_op);
+#endif
 }
 
 void finalize() {

--- a/src/mpi_impl.cpp
+++ b/src/mpi_impl.cpp
@@ -133,8 +133,17 @@ void init(int& argc, char**& argv) {
 void finalize() {
   int flag;
   MPI_Finalized(&flag);
-  if (!flag && initialized_mpi) {
-    MPI_Finalize();
+  if (!flag) {
+#ifdef AL_HAS_HALF
+    // Clean up reduction operations.
+    MPI_Op_free(&half_sum_op);
+    MPI_Op_free(&half_prod_op);
+    MPI_Op_free(&half_min_op);
+    MPI_Op_free(&half_max_op);
+#endif
+    if (initialized_mpi) {
+      MPI_Finalize();
+    }
   }
 }
 

--- a/test/op_dispatcher.hpp
+++ b/test/op_dispatcher.hpp
@@ -179,6 +179,9 @@ template <> struct IsTypeSupportedByMPI<unsigned long long> : std::true_type {};
 template <> struct IsTypeSupportedByMPI<float> : std::true_type {};
 template <> struct IsTypeSupportedByMPI<double> : std::true_type {};
 template <> struct IsTypeSupportedByMPI<long double> : std::true_type {};
+#ifdef AL_HAS_HALF
+template <> struct IsTypeSupportedByMPI<__half> : std::true_type {};
+#endif
 
 // Traits for reduction operator support.
 template <typename Backend, Al::ReductionOperator op>

--- a/test/op_runner_impl.hpp
+++ b/test/op_runner_impl.hpp
@@ -165,7 +165,7 @@ public:
   void run_mpi_impl(std::vector<T>& input,
                     std::vector<T>& output,
                     typename Backend::comm_type& comm) {
-    MPI_Op reduction_op = Al::internal::mpi::ReductionOperator2MPI_Op(
+    MPI_Op reduction_op = Al::internal::mpi::ReductionOperator2MPI_Op<T>(
       this->get_options().reduction_op);
     MPI_Allreduce(this->buf_or_inplace(input.data()), output.data(),
                   this->get_options().inplace ? output.size() : input.size(),
@@ -575,7 +575,7 @@ public:
                     std::vector<T>& output,
                     typename Backend::comm_type& comm) {
     int root = this->get_options().root;
-    MPI_Op reduction_op = Al::internal::mpi::ReductionOperator2MPI_Op(
+    MPI_Op reduction_op = Al::internal::mpi::ReductionOperator2MPI_Op<T>(
       this->get_options().reduction_op);
     // Account for in-place only being used at the root.
     void* sendbuf = (comm.rank() == root)
@@ -641,7 +641,7 @@ public:
   void run_mpi_impl(std::vector<T>& input,
                     std::vector<T>& output,
                     typename Backend::comm_type& comm) {
-    MPI_Op reduction_op = Al::internal::mpi::ReductionOperator2MPI_Op(
+    MPI_Op reduction_op = Al::internal::mpi::ReductionOperator2MPI_Op<T>(
       this->get_options().reduction_op);
     MPI_Reduce_scatter_block(this->buf_or_inplace(input.data()), output.data(),
                              (this->get_options().inplace ? output.size() : input.size()) / comm.size(),
@@ -697,7 +697,7 @@ public:
   void run_mpi_impl(std::vector<T>& input,
                     std::vector<T>& output,
                     typename Backend::comm_type& comm) {
-    MPI_Op reduction_op = Al::internal::mpi::ReductionOperator2MPI_Op(
+    MPI_Op reduction_op = Al::internal::mpi::ReductionOperator2MPI_Op<T>(
       this->get_options().reduction_op);
     std::vector<int> counts = Al::internal::mpi::intify_size_t_vector(
       this->get_options().recv_counts);

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -48,9 +48,9 @@ hang_timeout = 5
 # Supported datatypes for backends.
 mpi_datatypes = ['char', 'schar', 'uchar', 'short', 'ushort', 'int', 'uint',
                  'long', 'ulong', 'longlong', 'ulonglong',
-                 'float', 'double',]# 'longdouble']
+                 'float', 'double', 'half']# 'longdouble']
 nccl_datatypes = ['char', 'uchar', 'int', 'uint', 'longlong', 'ulonglong',
-                  'float', 'double']
+                  'float', 'double', 'half']
 # Standard sets of operations.
 # inplace is one of 'both', True, or False.
 # root is either True or False.

--- a/test/test_utils_ht.hpp
+++ b/test/test_utils_ht.hpp
@@ -118,6 +118,9 @@ template <> struct IsTypeSupported<Al::HostTransferBackend, unsigned long long> 
 template <> struct IsTypeSupported<Al::HostTransferBackend, float> : std::true_type {};
 template <> struct IsTypeSupported<Al::HostTransferBackend, double> : std::true_type {};
 template <> struct IsTypeSupported<Al::HostTransferBackend, long double> : std::true_type {};
+#ifdef AL_HAS_HALF
+template <> struct IsTypeSupported<Al::HostTransferBackend, __half> : std::true_type {};
+#endif
 
 // Reduction operator support (all are supported).
 template <Al::ReductionOperator op>

--- a/test/test_utils_mpi.hpp
+++ b/test/test_utils_mpi.hpp
@@ -66,6 +66,9 @@ template <> struct IsTypeSupported<Al::MPIBackend, unsigned long long> : std::tr
 template <> struct IsTypeSupported<Al::MPIBackend, float> : std::true_type {};
 template <> struct IsTypeSupported<Al::MPIBackend, double> : std::true_type {};
 template <> struct IsTypeSupported<Al::MPIBackend, long double> : std::true_type {};
+#ifdef AL_HAS_HALF
+template <> struct IsTypeSupported<Al::MPIBackend, __half> : std::true_type {};
+#endif
 
 // Reduction operator support (all are supported).
 template <Al::ReductionOperator op>

--- a/test/test_utils_nccl.hpp
+++ b/test/test_utils_nccl.hpp
@@ -49,25 +49,6 @@ struct VectorType<T, Al::NCCLBackend> {
   }
 };
 
-// Specialization for half. Standard RNGs do not support half.
-template <> struct VectorType<__half, Al::NCCLBackend> {
-  using type = CUDAVector<__half>;
-
-  static type gen_data(size_t count, AlGpuStream_t stream = 0) {
-    auto&& host_data = VectorType<float, Al::MPIBackend>::gen_data(count);
-    std::vector<__half> host_data_half(count);
-    for (size_t i = 0; i < count; ++i) {
-      host_data_half[i] = __float2half(host_data[i]);
-    }
-    CUDAVector<__half> data(host_data_half, stream);
-    return data;
-  }
-
-  static std::vector<__half> copy_to_host(const type& v) {
-    return v.copyout();
-  }
-};
-
 // Specialize to use the Aluminum stream pool, and size it appropriately.
 template <>
 struct StreamManager<Al::NCCLBackend> {


### PR DESCRIPTION
This adds support for half to the MPI and Host-Transfer backends, and support for testing half datatypes across all backends.

Note that CPU-side half computations are emulated with fp32. They are therefore slower and may not round in the same way as performing native fp16 operations.

This requires half support to be provided. Currently this is via either the HIP/ROCm or CUDA support. In the future we may support other sources for half.

Closes #171. Closes #104.