### PR TITLE
Bfloat16 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ if (ALUMINUM_ENABLE_CUDA)
   #   - CUDA::nvToolsExt
 
   if (ALUMINUM_ENABLE_NCCL)
-    find_package(NCCL 2.7.0 REQUIRED)
+    find_package(NCCL 2.10.0 REQUIRED)
     set(AL_HAS_NCCL TRUE)
   endif ()
 
@@ -355,7 +355,7 @@ if (ALUMINUM_ENABLE_ROCM)
   endif ()
 
   if (ALUMINUM_ENABLE_NCCL)
-    find_package(rccl 2.7.0 CONFIG QUIET
+    find_package(rccl 2.10.0 CONFIG QUIET
       HINTS ${RCCL_DIR} $ENV{RCCL_DIR} ${AL_ROCM_PATH}
       PATH_SUFFIXES lib64/cmake/rccl lib/cmake/rccl
       NO_DEFAULT_PATH)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For GPU backends (`NCCL` and `HostTransfer`):
 * CUB (any recent version)
 
 For the `NCCL`/`RCCL` backend:
-* NCCL (for Nvidia GPUs) or RCCL (for AMD GPUs), at least version 2.7.0
+* NCCL (for Nvidia GPUs) or RCCL (for AMD GPUs), at least version 2.10.0
 
 ### Building
 

--- a/include/aluminum/datatypes.hpp
+++ b/include/aluminum/datatypes.hpp
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.  Produced at the
+// Lawrence Livermore National Laboratory in collaboration with University of
+// Illinois Urbana-Champaign.
+//
+// Written by the LBANN Research Team (N. Dryden, N. Maruyama, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-756777.
+// All rights reserved.
+//
+// This file is part of Aluminum GPU-aware Communication Library. For details, see
+// http://software.llnl.gov/Aluminum or https://github.com/LLNL/Aluminum.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+// This file identifies support for different specialized datatypes and
+// provides some basic things for them as needed.
+
+#include <Al_config.hpp>
+
+// IEEE 16 bit floating point (i.e., fp16 or half).
+
+#if defined AL_HAS_ROCM
+#include <hip/hip_fp16.h>
+#define AL_HAS_HALF 1
+#elif defined AL_HAS_CUDA
+#include <cuda_fp16.h>
+#define AL_HAS_HALF 1
+#endif
+
+// Brain floating point 16 (bfloat16).
+
+#if defined AL_HAS_ROCM
+#include <hip/hip_bfloat16.h>
+#define AL_HAS_BFLOAT 1
+using al_bfloat16 = hip_bfloat16;
+
+// Provide these for compatibility with CUDA.
+inline al_bfloat16 __float2bfloat16(const float a) {
+  return al_bfloat16(a);
+}
+inline float __bfloat162float(const al_bfloat16 a) {
+  return static_cast<float>(a);
+}
+#elif defined AL_HAS_CUDA
+#include <cuda_bf16.h>
+#define AL_HAS_BFLOAT 1
+using al_bfloat16 = __nv_bfloat16;
+#endif

--- a/include/aluminum/mpi/utils.hpp
+++ b/include/aluminum/mpi/utils.hpp
@@ -63,6 +63,10 @@ template <> inline MPI_Datatype TypeMap<long double>() { return MPI_LONG_DOUBLE;
 // This is dispatched to special reduction operators when needed.
 template <> inline MPI_Datatype TypeMap<__half>() { return MPI_SHORT; }
 #endif
+#ifdef AL_HAS_BFLOAT
+// Same as for half.
+template <> inline MPI_Datatype TypeMap<al_bfloat16>() { return MPI_SHORT; }
+#endif
 
 
 /** Return either sendbuf or MPI_IN_PLACE. */
@@ -108,6 +112,17 @@ extern MPI_Op half_min_op;
 extern MPI_Op half_max_op;
 #endif
 
+#ifdef AL_HAS_BFLOAT
+/** Sum operator for bfloat. */
+extern MPI_Op bfloat_sum_op;
+/** Product operator for bfloat. */
+extern MPI_Op bfloat_prod_op;
+/** Min operator for bfloat. */
+extern MPI_Op bfloat_min_op;
+/** Max operator for bfloat. */
+extern MPI_Op bfloat_max_op;
+#endif
+
 /** Convert a ReductionOperator to the corresponding MPI_Op. */
 template <typename T>
 inline MPI_Op ReductionOperator2MPI_Op(ReductionOperator op) {
@@ -149,6 +164,24 @@ inline MPI_Op ReductionOperator2MPI_Op<__half>(ReductionOperator op) {
     return half_min_op;
   case ReductionOperator::max:
     return half_max_op;
+  default:
+    throw_al_exception("Reduction operator not supported");
+  }
+}
+#endif
+
+#ifdef AL_HAS_BFLOAT
+template <>
+inline MPI_Op ReductionOperator2MPI_Op<al_bfloat16>(ReductionOperator op) {
+  switch (op) {
+  case ReductionOperator::sum:
+    return bfloat_sum_op;
+  case ReductionOperator::prod:
+    return bfloat_prod_op;
+  case ReductionOperator::min:
+    return bfloat_min_op;
+  case ReductionOperator::max:
+    return bfloat_max_op;
   default:
     throw_al_exception("Reduction operator not supported");
   }

--- a/include/aluminum/nccl_impl.hpp
+++ b/include/aluminum/nccl_impl.hpp
@@ -158,6 +158,7 @@ template <> inline ncclDataType_t TypeMap<unsigned int>() { return ncclUint32; }
 template <> inline ncclDataType_t TypeMap<long long int>() { return ncclInt64; }
 template <> inline ncclDataType_t TypeMap<unsigned long long int>() { return ncclUint64; }
 template <> inline ncclDataType_t TypeMap<__half>() { return ncclHalf; }
+template <> inline ncclDataType_t TypeMap<al_bfloat16>() { return ncclBfloat16; }
 template <> inline ncclDataType_t TypeMap<float>() { return ncclFloat; }
 template <> inline ncclDataType_t TypeMap<double>() { return ncclDouble; }
 

--- a/test/op_dispatcher.hpp
+++ b/test/op_dispatcher.hpp
@@ -182,6 +182,9 @@ template <> struct IsTypeSupportedByMPI<long double> : std::true_type {};
 #ifdef AL_HAS_HALF
 template <> struct IsTypeSupportedByMPI<__half> : std::true_type {};
 #endif
+#ifdef AL_HAS_BFLOAT
+template <> struct IsTypeSupportedByMPI<al_bfloat16> : std::true_type {};
+#endif
 
 // Traits for reduction operator support.
 template <typename Backend, Al::ReductionOperator op>

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -48,9 +48,9 @@ hang_timeout = 5
 # Supported datatypes for backends.
 mpi_datatypes = ['char', 'schar', 'uchar', 'short', 'ushort', 'int', 'uint',
                  'long', 'ulong', 'longlong', 'ulonglong',
-                 'float', 'double', 'half']# 'longdouble']
+                 'float', 'double', 'half', 'bfloat16']# 'longdouble']
 nccl_datatypes = ['char', 'uchar', 'int', 'uint', 'longlong', 'ulonglong',
-                  'float', 'double', 'half']
+                  'float', 'double', 'half', 'bfloat16']
 # Standard sets of operations.
 # inplace is one of 'both', True, or False.
 # root is either True or False.

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -165,6 +165,20 @@ struct RandVectorGen<__half> {
   }
 };
 #endif
+#ifdef AL_HAS_BFLOAT
+// Specialization for bfloat. Standard RNGs do not support bfloat.
+template <>
+struct RandVectorGen<al_bfloat16> {
+  template <typename Generator>
+  static std::vector<al_bfloat16> gen(size_t count, Generator& g) {
+    std::vector<al_bfloat16> v(count);
+    for (size_t i = 0; i < count; ++i) {
+      v[i] = __float2bfloat16(gen_random_val<float>(g));
+    }
+    return v;
+  }
+};
+#endif
 
 /**
  * Identify the type of vector to be used for each backend.
@@ -287,6 +301,9 @@ void dispatch_to_backend_type_helper(cxxopts::ParseResult& parsed_opts,
     {"longdouble", [&]() { functor.template operator()<Backend, long double>(parsed_opts); } },
 #ifdef AL_HAS_HALF
     {"half", [&]() { functor.template operator()<Backend, __half>(parsed_opts); } },
+#endif
+#ifdef AL_HAS_BFLOAT
+    {"bfloat16", [&]() { functor.template operator()<Backend, al_bfloat16>(parsed_opts); } },
 #endif
   };
   auto datatype = parsed_opts["datatype"].as<std::string>();

--- a/test/test_utils_ht.hpp
+++ b/test/test_utils_ht.hpp
@@ -121,6 +121,9 @@ template <> struct IsTypeSupported<Al::HostTransferBackend, long double> : std::
 #ifdef AL_HAS_HALF
 template <> struct IsTypeSupported<Al::HostTransferBackend, __half> : std::true_type {};
 #endif
+#ifdef AL_HAS_BFLOAT
+template <> struct IsTypeSupported<Al::HostTransferBackend, al_bfloat16> : std::true_type {};
+#endif
 
 // Reduction operator support (all are supported).
 template <Al::ReductionOperator op>

--- a/test/test_utils_mpi.hpp
+++ b/test/test_utils_mpi.hpp
@@ -69,6 +69,9 @@ template <> struct IsTypeSupported<Al::MPIBackend, long double> : std::true_type
 #ifdef AL_HAS_HALF
 template <> struct IsTypeSupported<Al::MPIBackend, __half> : std::true_type {};
 #endif
+#ifdef AL_HAS_BFLOAT
+template <> struct IsTypeSupported<Al::MPIBackend, al_bfloat16> : std::true_type {};
+#endif
 
 // Reduction operator support (all are supported).
 template <Al::ReductionOperator op>

--- a/test/test_utils_nccl.hpp
+++ b/test/test_utils_nccl.hpp
@@ -112,6 +112,7 @@ template <> struct IsTypeSupported<Al::NCCLBackend, unsigned int> : std::true_ty
 template <> struct IsTypeSupported<Al::NCCLBackend, long long int> : std::true_type {};
 template <> struct IsTypeSupported<Al::NCCLBackend, unsigned long long int> : std::true_type {};
 template <> struct IsTypeSupported<Al::NCCLBackend, __half> : std::true_type {};
+template <> struct IsTypeSupported<Al::NCCLBackend, al_bfloat16> : std::true_type {};
 template <> struct IsTypeSupported<Al::NCCLBackend, float> : std::true_type {};
 template <> struct IsTypeSupported<Al::NCCLBackend, double> : std::true_type {};
 


### PR DESCRIPTION
This add bfloat16 support to all Aluminum backends.

Similar caveats as with half apply: On platforms without native support, we are emulating bfloat16 by converting to float. Note NCCL supports bfloat16 on any platform with CUDA 11, but if the GPU is not at least Ampere, there will not be native support and reductions will be emulated with floats (hence, slow).

Bfloat16 requires CUDA 11 or a similarly recent version of HIP/ROCm, and NCCL/RCCL v2.10 or later. These are now required minimums for Aluminum.

Closes #170.