### PR TITLE
Average reductions

### DIFF
--- a/include/aluminum/base.hpp
+++ b/include/aluminum/base.hpp
@@ -70,7 +70,7 @@ private:
 
 /** Predefined reduction operations. */
 enum class ReductionOperator {
-  sum, prod, min, max, lor, land, lxor, bor, band, bxor
+  sum, prod, min, max, lor, land, lxor, bor, band, bxor, avg
 };
 
 } // namespace Al

--- a/include/aluminum/nccl_impl.hpp
+++ b/include/aluminum/nccl_impl.hpp
@@ -145,6 +145,8 @@ inline ncclRedOp_t ReductionOperator2ncclRedOp(ReductionOperator op) {
     return ncclMin;
   case ReductionOperator::max:
     return ncclMax;
+  case ReductionOperator::avg:
+    return ncclAvg;
   default:
     throw_al_exception("Reduction operator not supported");
   }

--- a/test/op_dispatcher.hpp
+++ b/test/op_dispatcher.hpp
@@ -75,7 +75,8 @@ Al::ReductionOperator get_reduction_op(const std::string redop_str) {
     {"lxor", Al::ReductionOperator::lxor},
     {"bor", Al::ReductionOperator::bor},
     {"band", Al::ReductionOperator::band},
-    {"bxor", Al::ReductionOperator::bxor}
+    {"bxor", Al::ReductionOperator::bxor},
+    {"avg", Al::ReductionOperator::avg},
   };
   auto i = op_lookup.find(redop_str);
   if (i == op_lookup.end()) {

--- a/test/test_utils_nccl.hpp
+++ b/test/test_utils_nccl.hpp
@@ -125,6 +125,8 @@ template <>
 struct IsReductionOpSupported<Al::NCCLBackend, Al::ReductionOperator::min> : std::true_type {};
 template <>
 struct IsReductionOpSupported<Al::NCCLBackend, Al::ReductionOperator::max> : std::true_type {};
+template <>
+struct IsReductionOpSupported<Al::NCCLBackend, Al::ReductionOperator::avg> : std::true_type {};
 
 // Backend name.
 template <> constexpr char AlBackendName<Al::NCCLBackend>[] = "nccl";


### PR DESCRIPTION
(Depends on #174.)

Add support for average reductions to the NCCL/RCCL backends (where they are supported natively).

As @benson31 points out, this is, technically, not a reduction operation. However, it does let you fuse two element-wise operations together.

These are currently unsupported in the MPI and host-transfer backend. (Mainly because average is not a reduction, and so annoying to implement with MPI reduction operators, instead requiring a pre- or post-communication step.)