### PR TITLE
Add the stream to trace entries.

### DIFF
--- a/include/aluminum/trace.hpp
+++ b/include/aluminum/trace.hpp
@@ -69,13 +69,17 @@ void save_trace_entry(std::string entry, bool progress = false);
 /** Record an operation to the trace log. */
 template <typename Backend, typename T, typename... Args>
 #ifdef AL_TRACE
-void record_op(std::string op, typename Backend::comm_type& comm, Args... args) {
-  std::stringstream ss;
-  ss << get_time() << ": "
+void record_op(std::string const& op,
+               typename Backend::comm_type const& comm,
+               Args&&... args) {
+  std::ostringstream ss;
+  ss << static_cast<size_t>(get_time()) << ": "
      << Backend::Name() << " "
+     << comm.get_stream() << " "
      << typeid(T).name() << " "
      << op << " "
      << comm.rank() << " " << comm.size() << " ";
+
   // See:
   // https://stackoverflow.com/questions/27375089/what-is-the-easiest-way-to-print-a-variadic-parameter-pack-using-stdostream
   using expander = int[];
@@ -83,7 +87,9 @@ void record_op(std::string op, typename Backend::comm_type& comm, Args... args) 
   save_trace_entry(ss.str(), false);
 }
 #else  // AL_TRACE
-void record_op(std::string, typename Backend::comm_type&, Args...) {
+void record_op(std::string const&,
+               typename Backend::comm_type const&,
+               Args&&...) {
 }
 #endif  // AL_TRACE
 

--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -56,9 +56,9 @@ void save_trace_entry(std::string entry, bool progress) {
   std::lock_guard<std::mutex> lock(log_mutex);
 #endif
   if (progress) {
-    pe_trace_log.push_back(entry);
+    pe_trace_log.push_back(std::move(entry));
   } else {
-    trace_log.push_back(entry);
+    trace_log.push_back(std::move(entry));
   }
 }
 


### PR DESCRIPTION
This adds the stream identifier (handle address, e.g.) to the trace entry. This can be useful for debugging complex apps.

The stream type must be stream output-able.