### PR TITLE
Improve progress engine binding flow

### DIFF
--- a/include/aluminum/progress.hpp
+++ b/include/aluminum/progress.hpp
@@ -141,10 +141,14 @@ class ProgressEngine {
   size_t num_bounded = 0;
   /** World communicator. */
   mpi::MPICommunicator* world_comm;
+  /** Core to bind the progress engine to. */
+  int core_to_bind = -1;
 #ifdef AL_HAS_CUDA
   /** Used to pass the original CUDA device to the progress engine thread. */
   std::atomic<int> cur_device;
 #endif
+  /** Initialize progress engine binding (must be called before bind). */
+  void bind_init();
   /**
    * Bind the progress engine to a core.
    * This binds to the last core in the NUMA node the process is in.

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -236,7 +236,9 @@ std::unordered_map<void*, ProgressEngine::InputQueue*> ProgressEngine::stream_to
 ProgressEngine::ProgressEngine() {
   stop_flag = false;
   started_flag = false;
+#ifdef AL_PE_START_ON_DEMAND
   doing_start_flag = false;
+#endif
   world_comm = new mpi::MPICommunicator(MPI_COMM_WORLD);
 #ifdef AL_PE_ADD_DEFAULT_STREAM
   // Initialze with the default stream.


### PR DESCRIPTION
This splits apart how binding the progress engine is done to avoid MPI collectives coming from the progress engine thread. This could cause issues when not all ranks participate in calls, leading to deadlocks. (There might also be multi-threading issues.)

This also fixes an unguarded use of a variable which might lead to compile errors.