### PR TITLE
Find the Threads dependency in the export

### DIFF
--- a/cmake/AluminumConfig.cmake.in
+++ b/cmake/AluminumConfig.cmake.in
@@ -26,6 +26,7 @@ set(MPI_CXX_COMPILER "@MPI_CXX_COMPILER@" CACHE FILEPATH
 find_package(MPI 3.0 REQUIRED COMPONENTS CXX)
 
 find_dependency(HWLOC)
+find_dependency(Threads)
 
 if (AL_HAS_ROCM)
   # The API for Aluminum does not require that HIP language support


### PR DESCRIPTION
CPU-only builds of the LBANN stack were revealing that this dependency was unsatisfied downstream. (This is perhaps problematic unto itself since they all should explicitly have this dependency, too, but that doesn't change the fact that it is indeed missing here.)

Closes #184.