### PR TITLE
In-place SendRecv

### DIFF
--- a/include/Al.hpp
+++ b/include/Al.hpp
@@ -1101,6 +1101,23 @@ void SendRecv(const T* sendbuf, size_t send_count, int dest,
                                 recvbuf, recv_count, src, comm);
 }
 
+/**
+ * Perform an in-place simultaneous send and recv.
+ * @param buf Input and output data; input will be overwritten.
+ * @param count Length of buf.
+ * @param dest Rank in comm to send to.
+ * @param src Rank in comm to receive from.
+ * @param comm Communicator to send/recv within.
+ */
+template <typename Backend, typename T>
+void SendRecv(T* buf, size_t count, int dest, int src,
+              typename Backend::comm_type& comm) {
+  internal::trace::record_op<Backend, T>("sendrecv", comm, buf, count,
+                                         dest, src);
+  Backend::template SendRecv<T>(buf, count, dest, src, comm);
+}
+
+/** Non-blocking version of SendRecv. */
 template <typename Backend, typename T>
 void NonblockingSendRecv(const T* sendbuf, size_t send_count, int dest,
                          T* recvbuf, size_t recv_count, int src,
@@ -1112,6 +1129,16 @@ void NonblockingSendRecv(const T* sendbuf, size_t send_count, int dest,
   Backend::template NonblockingSendRecv<T>(sendbuf, send_count, dest,
                                            recvbuf, recv_count, src,
                                            comm, req);
+}
+
+/** In-place version on NonblockingSendRecv; same semantics apply. */
+template <typename Backend, typename T>
+void NonblockingSendRecv(T* buf, size_t count, int dest, int src,
+                         typename Backend::comm_type& comm,
+                         typename Backend::req_type& req) {
+  internal::trace::record_op<Backend, T>("nonblocking-sendrecv", comm,
+                                         buf, count, dest, src);
+  Backend::template NonblockingSendRecv<T>(buf, count, dest, src, comm, req);
 }
 
 /**

--- a/include/aluminum/ht_impl.hpp
+++ b/include/aluminum/ht_impl.hpp
@@ -229,6 +229,12 @@ class HostTransferBackend {
   }
 
   template <typename T>
+  static void SendRecv(T* buf, size_t count, int dest, int src, comm_type& comm) {
+    // The way we copy buffers means this is safe.
+    SendRecv(buf, count, dest, buf, count, src, comm);
+  }
+
+  template <typename T>
   static void NonblockingSendRecv(const T* sendbuf, size_t send_count, int dest,
                                   T* recvbuf, size_t recv_count, int src,
                                   comm_type& comm, req_type& req) {
@@ -237,6 +243,13 @@ class HostTransferBackend {
     do_sendrecv(sendbuf, send_count, dest, recvbuf, recv_count, src, comm,
                 internal_stream);
     setup_completion_event(internal_stream, comm, req);
+  }
+
+  template <typename T>
+  static void NonblockingSendRecv(T* buf, size_t count, int dest, int src,
+                                  comm_type& comm, req_type& req) {
+    // The way we copy buffers means this is safe.
+    NonblockingSendRecv(buf, count, dest, buf, count, src, comm, req);
   }
 
   template <typename T>

--- a/include/aluminum/mpi_impl.hpp
+++ b/include/aluminum/mpi_impl.hpp
@@ -237,6 +237,11 @@ class MPIBackend {
   }
 
   template <typename T>
+  static void SendRecv(T* buf, size_t count, int dest, int src, comm_type& comm) {
+    SendRecv(internal::IN_PLACE<T>(), count, dest, buf, count, src, comm);
+  }
+
+  template <typename T>
   static void NonblockingSendRecv(const T* sendbuf, size_t send_count, int dest,
                                   T* recvbuf, size_t recv_count, int src,
                                   comm_type& comm, req_type& req) {
@@ -245,6 +250,13 @@ class MPIBackend {
     internal::mpi::passthrough_nb_sendrecv(sendbuf, send_count, dest,
                                            recvbuf, recv_count, src,
                                            comm, req);
+  }
+
+  template <typename T>
+  static void NonblockingSendRecv(T* buf, size_t count, int dest, int src,
+                                  comm_type& comm, req_type& req) {
+    NonblockingSendRecv(internal::IN_PLACE<T>(), count, dest, buf, count, src,
+                        comm, req);
   }
 
   template <typename T>

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -71,7 +71,7 @@ vector_coll_ops = [OpDesc('allgatherv'),
                    OpDesc('scatterv', root=True)]
 pt2pt_ops = [OpDesc('send', inplace=False, min_procs=2),
              OpDesc('recv', inplace=False, min_procs=2),
-             OpDesc('sendrecv', inplace=False, min_procs=2)]
+             OpDesc('sendrecv', inplace='both', min_procs=2)]
 
 # Full set of cases.
 test_cases = {
@@ -239,6 +239,10 @@ def run_test(args, num_procs, backend, operator, datatype, inplace,
         print('[Pass] ' + test_desc, flush=True)
     else:
         print('[Fail] ' + test_desc, flush=True)
+        if isinstance(r.args, str):
+            print(r.args, flush=True)
+        else:
+            print(' '.join(r.args), flush=True)
         if r.stdout:
             print(r.stdout, flush=True)
         if r.stderr:


### PR DESCRIPTION
This adds an in-place version of SendRecv (analogous to `MPI_Sendrecv_replace`).