### PR TITLE
Fix an issue with RCCL linkage in ROCm 5.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,9 @@ if (ALUMINUM_ENABLE_ROCM)
       PATH_SUFFIXES lib64/cmake/rccl lib/cmake/rccl
       NO_DEFAULT_PATH)
     find_package(rccl CONFIG REQUIRED)
+
+    find_library(AL_LIB_RT rt)
+
     message(STATUS "Found RCCL: ${rccl_DIR}")
     set(AL_HAS_NCCL TRUE)
   endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,10 @@ if (AL_HAS_ROCM)
     ${ROCM_SMI_LIBRARY}
     ${Roctracer_LIBRARIES})
 
+  if (AL_LIB_RT)
+    target_link_libraries(Al PUBLIC "${AL_LIB_RT}")
+  endif ()
+
   # HIP language files are detected by the ".hip" extension. Since
   # we're upcycling ".cu" files for now, we just set their LANGUAGE to
   # be HIP.


### PR DESCRIPTION
Only affects ROCm builds. Should never have adverse effects.