### PR TITLE
Change default stream pool size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ set(AL_DESTRUCTIVE_INTERFERENCE_SIZE 128
   CACHE STRING
   "Minimum size in bytes to avoid destructive interference")
 
-set(AL_CUDA_STREAM_POOL_SIZE 5
+set(AL_CUDA_STREAM_POOL_SIZE 1
   CACHE STRING
   "Number of CUDA streams in the default stream pool")
 


### PR DESCRIPTION
This sets the default stream pool size to 1. This helps mitigate issues with using multiple communications running the GPU out of resources and leading to deadlocks (see [here](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html#using-multiple-nccl-communicators-concurrently)).