### PR TITLE
Finalize NCCL communicators before destroying them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ if (ALUMINUM_ENABLE_CUDA)
   #   - CUDA::nvToolsExt
 
   if (ALUMINUM_ENABLE_NCCL)
-    find_package(NCCL 2.10.0 REQUIRED)
+    find_package(NCCL 2.14.0 REQUIRED)
     set(AL_HAS_NCCL TRUE)
   endif ()
 

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -18,8 +18,8 @@ The accelerator backends (``NCCL``, ``HostTransfer``) require:
 
 The ``NCCL``/``RCCL`` backend additionally requires:
 
-* For Nvidia GPUs: NCCL 2.10.0 or later
-* For AMD GPUs: RCCL 2.10.0 or later (this is usually bundled with HIP/ROCm installs)
+* For Nvidia GPUs: NCCL 2.14.0 or later
+* For AMD GPUs: RCCL 2.14.0 or later (this is usually bundled with HIP/ROCm installs)
 
 Aluminum uses CMake and an out-of-source build is required.
 A basic build can be done with:

--- a/src/nccl_impl.cpp
+++ b/src/nccl_impl.cpp
@@ -56,6 +56,7 @@ NCCLCommunicator::~NCCLCommunicator() {
   // Only destroy resources if the driver is still loaded.
   if (AlGpuGetDevice(&d) == AlGpuSuccess) {
     try {
+      AL_CHECK_NCCL(ncclCommFinalize(m_nccl_comm));
       AL_CHECK_NCCL(ncclCommDestroy(m_nccl_comm));
     } catch (const al_exception& e) {
       std::cerr << "Caught exception in NCCLCommunicator destructor: "


### PR DESCRIPTION
NCCL documentation recommends calling finalize before destroying communicators.

Bump minimum NCCL version to 2.14, as that is when `ncclCommFinalize` was introduced.