### PR TITLE
CUDA 12 compatibility

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -32,11 +32,6 @@ foreach(src IN LISTS AL_BENCHMARK_SOURCES AL_GPU_BENCHMARK_SOURCES)
     ${_benchmark_exe_name} SYSTEM PRIVATE
     ${CMAKE_SOURCE_DIR}/third_party/cxxopts/include)
 
-  # Use more caution now that "AL_HAS_CUDA" is overloaded.
-  if (AL_HAS_CUDA AND NOT AL_HAS_ROCM)
-    target_link_libraries(${_benchmark_exe_name} PUBLIC cuda)
-  endif ()
-
   # FIXME: Hopefully this can be removed in a future version of ROCm.
   if (AL_HAS_ROCM AND AL_BUILD_TYPE_UPPER MATCHES "DEBUG")
     target_compile_options(${_benchmark_exe_name} PRIVATE "-O0")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,11 +55,6 @@ foreach(src ${AL_TEST_SOURCES})
     SYSTEM PRIVATE
     ${CMAKE_SOURCE_DIR}/third_party/cxxopts/include)
   target_link_libraries(${_test_exe_name} PRIVATE Al aluminum_test_headers)
-  if (AL_HAS_CUDA AND NOT AL_HAS_ROCM)
-    target_link_libraries(${_test_exe_name} PUBLIC cuda)
-  endif()
-  target_link_libraries(${_test_exe_name} PRIVATE Threads::Threads)
-
   # FIXME: Hopefully this can be removed in a future version of ROCm.
   if (AL_HAS_ROCM AND AL_BUILD_TYPE_UPPER MATCHES "DEBUG")
     target_compile_options(${_test_exe_name} PRIVATE "-O0")
@@ -71,12 +66,9 @@ if (AL_HAS_MPI_CUDA_RMA AND NOT AL_HAS_ROCM)
   target_include_directories(
     test_rma_ring.exe SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/third_party/cxxopts/include)
   target_link_libraries(test_rma_ring.exe PRIVATE Al)
-  target_link_libraries(test_rma_ring.exe PUBLIC cuda)
   add_executable(test_rma_halo_exchange.exe
     test_rma_halo_exchange.cpp ${TEST_HEADERS})
   target_include_directories(
     test_rma_halo_exchange.exe SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/third_party/cxxopts/include)
   target_link_libraries(test_rma_halo_exchange.exe PRIVATE Al)
-  target_link_libraries(test_rma_halo_exchange.exe PUBLIC cuda)
-  target_link_libraries(${_test_exe_name} PRIVATE Threads::Threads)
 endif ()


### PR DESCRIPTION
Fix a compilation error under CUDA 12 due to changing CUDA APIs.

@benson31 I am still getting link errors, likely due to some CMake issue.