### PR TITLE
Update cxxopts

### DIFF
--- a/benchmark/benchmark_ops.cpp
+++ b/benchmark/benchmark_ops.cpp
@@ -234,8 +234,6 @@ struct benchmark_dispatcher {
 };
 
 int main(int argc, char** argv) {
-  test_init_aluminum(argc, argv);
-
   cxxopts::Options options("benchmark_ops", "Benchmark Aluminum operations");
   options.add_options()
     ("op", "Operator to benchmark", cxxopts::value<std::string>())
@@ -262,14 +260,14 @@ int main(int argc, char** argv) {
   auto parsed_opts = options.parse(argc, argv);
 
   if (parsed_opts.count("help")) {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    if (rank == 0) {
+    int rank = get_global_rank(false);  // Returns -1 if not found.
+    if (rank <= 0) {
       std::cout << options.help() << std::endl;
     }
-    test_fini_aluminum();
     std::exit(0);
   }
+
+  test_init_aluminum(argc, argv);
 
   // Simple validation.
   if (!parsed_opts.count("op")) {

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -405,8 +405,6 @@ struct test_dispatcher {
 };
 
 int main(int argc, char** argv) {
-  test_init_aluminum(argc, argv);
-
   cxxopts::Options options("test_ops", "Compare Aluminum operators with MPI");
   options.add_options()
     ("op", "Operator to test", cxxopts::value<std::string>())
@@ -433,15 +431,17 @@ int main(int argc, char** argv) {
     ("help", "Print help");
   auto parsed_opts = options.parse(argc, argv);
 
+  // Print help before initializing.
   if (parsed_opts.count("help")) {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    if (rank == 0) {
+    // Attempt to determine the global rank, but do not fail if we cannot.
+    int rank = get_global_rank(false);  // Returns -1 if not found.
+    if (rank <= 0) {
       std::cout << options.help() << std::endl;
     }
-    test_fini_aluminum();
     std::exit(0);
   }
+
+  test_init_aluminum(argc, argv);
 
   if (parsed_opts.count("hang-rank")) {
     hang_for_debugging(parsed_opts["hang-rank"].as<int>());

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -399,6 +399,32 @@ inline int get_number_of_gpus() {
 
 #endif  /** AL_HAS_CUDA */
 
+/**
+ * Attempt to identify the global rank from the environment.
+ *
+ * If this fails, optionally abort or return -1.
+ */
+inline int get_global_rank(bool required = true) {
+  char* env = std::getenv("MV2_COMM_WORLD_RANK");
+  if (!env) {
+    env = std::getenv("OMPI_COMM_WORLD_RANK");
+  }
+  if (!env) {
+    env = std::getenv("SLURM_PROCID");
+  }
+  if (!env) {
+    env = std::getenv("FLUX_TASK_RANK");
+  }
+  if (!env) {
+    if (required) {
+      std::cerr << "Cannot determine global rank" << std::endl;
+      std::abort();
+    }
+    return -1;
+  }
+  return std::atoi(env);
+}
+
 /** Attempt to identify the local rank on a node from the environment. */
 inline int get_local_rank() {
   char* env = std::getenv("MV2_COMM_WORLD_LOCAL_RANK");


### PR DESCRIPTION
Bump cxxopts version. Additionally, support `--help` in the tests/benchmarks without Aluminum initialization, which should make it easier to run these without an MPI launcher.