### PR TITLE
Fix HT alltoallv memcpy

### DIFF
--- a/include/aluminum/ht/alltoallv.hpp
+++ b/include/aluminum/ht/alltoallv.hpp
@@ -64,16 +64,16 @@ public:
       // If doing an in-place operation, transfer directly to host_recvbuf.
       for (size_t i = 0; i < recv_counts_.size(); ++i) {
         AL_CHECK_CUDA(AlGpuMemcpyAsync(host_recvbuf + recv_displs_[i],
-                                      recvbuf + recv_displs_[i],
-                                      sizeof(T)*recv_counts_[i],
-                                      AlGpuMemcpyDeviceToHost, stream_));
+                                       recvbuf + recv_displs_[i],
+                                       sizeof(T)*recv_counts_[i],
+                                       AlGpuMemcpyDeviceToHost, stream_));
       }
     } else {
       for (size_t i = 0; i < send_counts_.size(); ++i) {
         AL_CHECK_CUDA(AlGpuMemcpyAsync(host_sendbuf + send_displs_[i],
-                                      sendbuf + send_displs_[i],
-                                      sizeof(T)*send_counts_[i],
-                                      AlGpuMemcpyDeviceToHost, stream_));
+                                       sendbuf + send_displs_[i],
+                                       sizeof(T)*send_counts_[i],
+                                       AlGpuMemcpyDeviceToHost, stream_));
       }
     }
     start_event.record(stream_);
@@ -84,9 +84,9 @@ public:
     // Transfer completed buffer back to device.
     for (size_t i = 0; i < recv_counts_.size(); ++i) {
       AL_CHECK_CUDA(AlGpuMemcpyAsync(recvbuf + recv_displs_[i],
-                                    host_recvbuf + recv_displs_[i],
-                                    sizeof(T)*recv_counts_[i],
-                                    AlGpuMemcpyDeviceToHost, stream_));
+                                     host_recvbuf + recv_displs_[i],
+                                     sizeof(T)*recv_counts_[i],
+                                     AlGpuMemcpyHostToDevice, stream_));
     }
     end_event.record(stream_);
   }


### PR DESCRIPTION
We used the wrong direction in one of the memcpys in the host-transfer alltoallv.

Curiously, this never showed up in testing, and indeed, testing continues to pass and manual verification indicates it is, in fact, producing the correct outputs (at least on Lassen). I hypothesize this is due to the unified memory eliminating the distinction between device and host pointers (from a correctness, not a performance, point-of-view). Unfortunately, I don't have a great way to test this hypothesis.