### PR TITLE
Add testing for communicator initialization/destruction

### DIFF
--- a/include/aluminum/ht/communicator.hpp
+++ b/include/aluminum/ht/communicator.hpp
@@ -47,7 +47,7 @@ class HostTransferCommunicator: public MPICommAndStreamWrapper<AlGpuStream_t> {
   HostTransferCommunicator()
     : HostTransferCommunicator(mpi::get_world_comm().get_comm(), 0) {}
   /** Use a particular MPI communicator and stream. */
-  HostTransferCommunicator(MPI_Comm comm_, AlGpuStream_t stream_)
+  HostTransferCommunicator(MPI_Comm comm_, AlGpuStream_t stream_ = 0)
     : MPICommAndStreamWrapper(comm_, stream_) {}
   /** Cannot copy this. */
   HostTransferCommunicator(const HostTransferCommunicator& other) = delete;


### PR DESCRIPTION
This is to help diagnose issues with communicator setup/teardown. It supports creating and destroying a backend's communicator type using `MPI_COMM_WORLD` and the default stream. It avoids most other testing machinery, but will use the standard hang detection.