### PR TITLE
User buffer registration

### DIFF
--- a/include/Al.hpp
+++ b/include/Al.hpp
@@ -1882,6 +1882,37 @@ bool Test(typename Backend::req_type& req);
 template <typename Backend>
 void Wait(typename Backend::req_type& req);
 
+/**
+ * Register memory with a communicator.
+ *
+ * For certain backends and situations, this may improve the
+ * performance of subsequent communication operations.
+ *
+ * @param[in] buf Buffer to register.
+ * @param[in] count Length of \p buffer in elements of type `T`.
+ * @param[in] comm Communicator to register the buffer with.
+ */
+template <typename Backend, typename T>
+void RegisterMemory(T* buf, size_t count, typename Backend::comm_type& comm) {
+  internal::trace::record_op<Backend, T>("register", comm, buf, count);
+  Backend::template RegisterMemory<T>(buf, count, comm);
+}
+
+/**
+ * Unregister memory with a communicator.
+ *
+ * The memory should have previously been registered with
+ * RegisterMemory.
+ *
+ * @param[in] buf Buffer to unregister.
+ * @param[in] comm Communicator to unregister the buffer from.
+ */
+template <typename Backend, typename T>
+void UnregisterMemory(T* buf, typename Backend::comm_type& comm) {
+  internal::trace::record_op<Backend, T>("unregister", comm, buf);
+  Backend::template UnregisterMemory<T>(buf, comm);
+}
+
 namespace ext {
 
 #ifdef AL_HAS_MPI_CUDA_RMA

--- a/include/aluminum/ht_impl.hpp
+++ b/include/aluminum/ht_impl.hpp
@@ -841,6 +841,17 @@ class HostTransferBackend {
     NonblockingScatterv<T>(buffer, buffer, counts, displs, root, comm, req, algo);
   }
 
+  template <typename T>
+  static void RegisterMemory(T*, size_t, comm_type&) {
+    // Registration is not supported with host-transfer, but we don't
+    // want this to fail to compile.
+  }
+
+  template <typename T>
+  static void UnregisterMemory(T*, comm_type&) {
+    // Registration is not supported with host-transfer.
+  }
+
   static std::string Name() { return "HostTransferBackend"; }
 
  private:

--- a/include/aluminum/mpi_impl.hpp
+++ b/include/aluminum/mpi_impl.hpp
@@ -926,6 +926,17 @@ class MPIBackend {
       internal::IN_PLACE<T>(), buffer, counts, displs, root, comm, req, algo);
   }
 
+  template <typename T>
+  static void RegisterMemory(T*, size_t, comm_type&) {
+    // Registration is not supported with MPI, but we don't want this
+    // to fail to compile.
+  }
+
+  template <typename T>
+  static void UnregisterMemory(T*, comm_type&) {
+    // Registration is not supported with MPI.
+  }
+
   static std::string Name() { return "MPIBackend"; }
 
 private:

--- a/test/op_runner.hpp
+++ b/test/op_runner.hpp
@@ -49,6 +49,7 @@ struct OpOptions {
   Al::ReductionOperator reduction_op = Al::ReductionOperator::sum;
   typename Backend::req_type req = Backend::null_req;
   AlgorithmOptions<Backend> algos;
+  bool register_memory = false;
 };
 
 /** Abstract base class for running an operator. */


### PR DESCRIPTION
This adds support for user buffer registration to the NCCL API.

As this is just a performance optimization/hint, to simplify users' lives, all backends implement this, but may do nothing.

Two points for future improvements:
1. Right now the NCCL backend does not use registered memory for its internal memory allocations (which show up in custom collective implementations). This is mainly because memory needs to be registered with a communicator, and I am not sure whether it can be shared across communicators.
2. Our internal interface to the NCCL registration system does not really handle the case where the same buffer is registered with different communicators. This is basically for the same reason.

I intend to fix these once I better understand how registration works with multiple communicators.