### PR TITLE
Defer all HWLOC calls until binding is required

### DIFF
--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -251,7 +251,6 @@ ProgressEngine::ProgressEngine() {
   AL_CHECK_CUDA(AlGpuGetDevice(&device));
   cur_device = device;
 #endif
-  bind_init();
 }
 
 ProgressEngine::~ProgressEngine() {}
@@ -434,6 +433,7 @@ void ProgressEngine::bind_init() {
 }
 
 void ProgressEngine::bind() {
+  bind_init();
   if (core_to_bind < 0) {
     std::cerr << mpi::get_world_comm().rank()
               << ": progress engine binding not initialized"


### PR DESCRIPTION
This moves `bind_init()` inside `bind()` to avoid hwloc calls if the progress engine is never started. This should allow us to avoid ALL hwloc calls in Aluminum that aren't strictly necessary at runtime. Now they will only be called if the progress engine is actually used.