### PR TITLE
Use find_package for ROCm-SMI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,10 +456,7 @@ if (ALUMINUM_ENABLE_ROCM)
   find_package(hipcub CONFIG REQUIRED)
 
   # (trb 01/03/2022): This is needed for HWLOC stuff to work correctly.
-  find_path(ROCM_SMI_INCLUDE_DIR rocm_smi/rocm_smi.h REQUIRED
-    HINTS ${AL_ROCM_PATH}/rocm_smi/include)
-  find_library(ROCM_SMI_LIBRARY rocm_smi64 REQUIRED
-    HINTS ${AL_ROCM_PATH}/rocm_smi/lib)
+  find_package(rocm_smi CONFIG REQUIRED)
 
   if (ALUMINUM_ENABLE_ROCTRACER)
     find_package(Roctracer MODULE COMPONENTS roctx)

--- a/cmake/AluminumConfig.cmake.in
+++ b/cmake/AluminumConfig.cmake.in
@@ -38,6 +38,7 @@ if (AL_HAS_ROCM)
   # be enabled; it only requires the host/device libraries be found.
   find_dependency(hip)
   find_dependency(hipcub)
+  find_dependency(rocm_smi)
 
   set(AL_ROCM_PATH "@AL_ROCM_PATH@")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,8 +101,6 @@ if (AL_HAS_ROCM)
   # END FIXME BLOCK
   ##############################
 
-  target_include_directories(Al PRIVATE
-    $<BUILD_INTERFACE:${ROCM_SMI_INCLUDE_DIR}>)
   target_link_libraries(Al PUBLIC
     hip::host
     hip::hipcub


### PR DESCRIPTION
The existing `find_path`/`find_library` infrastructure is outdated. This just updates that.