### PR TITLE
Name threads to help debugging

### DIFF
--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -96,7 +96,10 @@
 #define AlGpuDefaultEventFlags cudaEventDefault
 #define AlGpuNoTimingEventFlags cudaEventDisableTiming
 #endif
-#endif // defined AL_GPU_RUNTIME_PREFIX
+#endif  // defined AL_GPU_RUNTIME_PREFIX
+
+/* Do not change this (POSIX requires it be 16). Includes trailing null. */
+#define AL_MAX_THREAD_NAME_LEN 16
 
 #ifdef AL_HAS_MPI_CUDA
 #cmakedefine AL_HAS_MPI_CUDA_RMA

--- a/src/nccl_impl.cpp
+++ b/src/nccl_impl.cpp
@@ -29,6 +29,8 @@
 #include "aluminum/nccl_impl.hpp"
 #include "aluminum/mpi/communicator.hpp"
 
+#include <stdlib.h>
+
 #include <exception>
 #include <mutex>
 #include <unordered_map>
@@ -76,6 +78,10 @@ namespace internal {
 namespace nccl {
 
 void init(int&, char**&) {
+  // To help debugging, set this environment variable for NCCL when it
+  // is not otherwise set, to get more helpful thread names.
+  setenv("NCCL_SET_THREAD_NAME", "1", 0);
+
   AL_CHECK_CUDA(AlGpuEventCreateWithFlags(&NCCLBackend::sync_event,
                                           AlGpuNoTimingEventFlags));
 }

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -29,6 +29,8 @@
 
 #include <Al_config.hpp>
 
+#include <pthread.h>
+
 #ifdef AL_HAS_NVPROF
 #include <nvToolsExtCuda.h>
 #include <nvToolsExtCudaRt.h>
@@ -38,12 +40,15 @@ namespace Al {
 namespace internal {
 namespace profiling {
 
-void name_thread(std::thread::native_handle_type handle, std::string name) {
+void name_thread([[maybe_unused]] std::thread::native_handle_type handle,
+                 [[maybe_unused]] std::string name) {
 #ifdef AL_HAS_NVPROF
   nvtxNameOsThreadA(handle, name.c_str());
-#else
-  (void) handle;
-  (void) name;
+#endif
+#ifdef _GNU_SOURCE
+  // Subtract 1 to account for the terminating null.
+  std::string name_resized = name.substr(0, AL_MAX_THREAD_NAME_LEN - 1);
+  pthread_setname_np(handle, name_resized.c_str());
 #endif
 }
 

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -269,7 +269,7 @@ void ProgressEngine::run() {
   doing_start_flag = true;
 #endif
   thread = std::thread(&ProgressEngine::engine, this);
-  profiling::name_thread(thread.native_handle(), "al-progress");
+  profiling::name_thread(thread.native_handle(), "AlProgress");
   startup_cv.wait(lock, [this] {return started_flag.load() ;});
 }
 

--- a/test/hang_watchdog.hpp
+++ b/test/hang_watchdog.hpp
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <pthread.h>
+
 #include <iostream>
 #include <thread>
 #include <mutex>
@@ -44,6 +46,9 @@ public:
   HangWatchdog(size_t timeout_ = 60, bool do_abort_ = true) :
     timeout(timeout_), do_abort(do_abort_) {
     watchdog = std::thread(&HangWatchdog::run, this);
+#ifdef _GNU_SOURCE
+    pthread_setname_np(watchdog.native_handle(), "HangWatchdog");
+#endif
   }
 
   ~HangWatchdog() {

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -29,6 +29,8 @@
 
 #include "Al.hpp"
 
+#include <unistd.h>
+
 #include <iostream>
 #include <vector>
 #include <limits>
@@ -351,7 +353,10 @@ inline void hang_for_debugging(int hang_rank) {
     if (hang_rank < 0 && rank == 0) {
       std::cout << "Hanging all ranks" << std::endl;
     } else if (rank == hang_rank) {
-      std::cout << "Hanging rank " << rank << std::endl;
+      char hostname[HOST_NAME_MAX];
+      gethostname(hostname, HOST_NAME_MAX);
+      std::cout << "Hanging rank " << rank << " (hostname " << hostname
+                << ", pid " << getpid() << ")" << std::endl;
     }
     volatile bool hang = true;
     while (hang) {}


### PR DESCRIPTION
Based on recent experience, it is helpful for threads to be named. This uses `pthread_setname_np` to do that, via the already-existing but mostly-unused `Al::internal::profiling::name_thread`. It also sets the `NCCL_SET_THREAD_NAME` environment variable (unless it is already set) to get NCCL to do the same.

I also made our hang output nicer.

Some notes:
- I have started using `[[maybe_unused]]` in some places when I poke at the code.
- We do not need to define `_GNU_SOURCE`; it's a bit nasty, but g++ and clang++ will both set it automatically (libstdc++/libc++ will break without it).
- For whatever reason, while there is a `std::getenv`, there is no `std::setenv`.
- The hang watchdog doesn't use `name_thread` because it previously didn't include any Aluminum headers and I didn't want to add them.