### PR TITLE
Support large-count MPI operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,13 @@ endif ()
 # Dependencies
 
 find_package(MPI 3.0 REQUIRED COMPONENTS CXX)
+if (MPI_CXX_VERSION VERSION_GREATER_EQUAL 4.0)
+  message(STATUS "MPI version >= 4.0, enabling large-count MPI support")
+  set(AL_HAS_LARGE_COUNT_MPI ON)
+else ()
+  message(STATUS "MPI version < 4.0, disabling large-count MPI support")
+  set(AL_HAS_LARGE_COUNT_MPI OFF)
+endif ()
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 

--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -124,3 +124,6 @@
 #cmakedefine AL_DISABLE_BACKGROUND_STREAMS
 
 #cmakedefine AL_USE_HWLOC
+
+/** Whether we built with an MPI that supports large counts. */
+#cmakedefine AL_HAS_LARGE_COUNT_MPI

--- a/include/aluminum/ht/allgather.hpp
+++ b/include/aluminum/ht/allgather.hpp
@@ -75,8 +75,9 @@ public:
 
 protected:
   void start_mpi_op() override {
-    MPI_Iallgather(MPI_IN_PLACE, count, mpi::TypeMap<T>(),
-                   host_mem, count, mpi::TypeMap<T>(), comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Iallgather)(
+      MPI_IN_PLACE, count, mpi::TypeMap<T>(),
+      host_mem, count, mpi::TypeMap<T>(), comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/ht/allreduce.hpp
+++ b/include/aluminum/ht/allreduce.hpp
@@ -73,8 +73,9 @@ class AllreduceAlState : public HostTransferCollectiveSignalAtEndState {
 
  protected:
   void start_mpi_op() override {
-    MPI_Iallreduce(MPI_IN_PLACE, host_mem, count, mpi::TypeMap<T>(),
-                   op, comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Iallreduce)(
+      MPI_IN_PLACE, host_mem, count, mpi::TypeMap<T>(),
+      op, comm, get_mpi_req());
   }
 
  private:

--- a/include/aluminum/ht/alltoall.hpp
+++ b/include/aluminum/ht/alltoall.hpp
@@ -66,8 +66,9 @@ public:
 
 protected:
   void start_mpi_op() override {
-    MPI_Ialltoall(MPI_IN_PLACE, count, mpi::TypeMap<T>(),
-                  host_mem, count, mpi::TypeMap<T>(), comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Ialltoall)(
+      MPI_IN_PLACE, count, mpi::TypeMap<T>(),
+      host_mem, count, mpi::TypeMap<T>(), comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/ht/bcast.hpp
+++ b/include/aluminum/ht/bcast.hpp
@@ -72,7 +72,8 @@ public:
 
 protected:
   void start_mpi_op() override {
-    MPI_Ibcast(host_mem, count, mpi::TypeMap<T>(), root, comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Ibcast)(
+      host_mem, count, mpi::TypeMap<T>(), root, comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/ht/gather.hpp
+++ b/include/aluminum/ht/gather.hpp
@@ -78,13 +78,15 @@ public:
 protected:
   void start_mpi_op() override {
     if (is_root) {
-      MPI_Igather(MPI_IN_PLACE, count, mpi::TypeMap<T>(),
-                  host_mem, count, mpi::TypeMap<T>(),
-                  root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Igather)(
+        MPI_IN_PLACE, count, mpi::TypeMap<T>(),
+        host_mem, count, mpi::TypeMap<T>(),
+        root, comm, get_mpi_req());
     } else {
-      MPI_Igather(host_mem, count, mpi::TypeMap<T>(),
-                  host_mem, count, mpi::TypeMap<T>(),
-                  root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Igather)(
+        host_mem, count, mpi::TypeMap<T>(),
+        host_mem, count, mpi::TypeMap<T>(),
+        root, comm, get_mpi_req());
     }
   }
 

--- a/include/aluminum/ht/gatherv.hpp
+++ b/include/aluminum/ht/gatherv.hpp
@@ -47,8 +47,8 @@ public:
                                   (displs_.back() + counts_.back()) :
                                   counts_[comm_.rank()])),
     send_count(counts_[comm_.rank()]),
-    counts(mpi::intify_size_t_vector(counts_)),
-    displs(mpi::intify_size_t_vector(displs_)),
+    counts(mpi::countify_size_t_vector(counts_)),
+    displs(mpi::displify_size_t_vector(displs_)),
     root(root_),
     comm(comm_.get_comm()) {
     // Transfer data from device to host.
@@ -86,21 +86,23 @@ public:
 protected:
   void start_mpi_op() override {
     if (is_root) {
-      MPI_Igatherv(MPI_IN_PLACE, send_count, mpi::TypeMap<T>(),
-                   host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
-                   root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Igatherv)(
+        MPI_IN_PLACE, send_count, mpi::TypeMap<T>(),
+        host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
+        root, comm, get_mpi_req());
     } else {
-      MPI_Igatherv(host_mem, send_count, mpi::TypeMap<T>(),
-                   host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
-                   root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Igatherv)(
+        host_mem, send_count, mpi::TypeMap<T>(),
+        host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
+        root, comm, get_mpi_req());
     }
   }
 
 private:
   T* host_mem;
   size_t send_count;
-  std::vector<int> counts;
-  std::vector<int> displs;
+  mpi::Al_mpi_count_vector_t counts;
+  mpi::Al_mpi_displ_vector_t displs;
   int root;
   MPI_Comm comm;
 };

--- a/include/aluminum/ht/pt2pt.hpp
+++ b/include/aluminum/ht/pt2pt.hpp
@@ -73,7 +73,8 @@ class SendAlState : public AlState {
 #ifdef AL_HAS_PROF
       prof_range = profiling::prof_start("HTSend MPI");
 #endif
-      MPI_Isend(mem, count, mpi::TypeMap<T>(), dest, pt2pt_tag, comm, &req);
+      AL_MPI_LARGE_COUNT_CALL(MPI_Isend)(
+        mem, count, mpi::TypeMap<T>(), dest, pt2pt_tag, comm, &req);
       send_started = true;
     }
     int flag;
@@ -127,7 +128,8 @@ class RecvAlState : public AlState {
 #ifdef AL_HAS_PROF
     prof_range = profiling::prof_start("HTRecv MPI");
 #endif
-    MPI_Irecv(mem, count, mpi::TypeMap<T>(), src, pt2pt_tag, comm, &req);
+    AL_MPI_LARGE_COUNT_CALL(MPI_Irecv)(
+      mem, count, mpi::TypeMap<T>(), src, pt2pt_tag, comm, &req);
   }
   PEAction step() override {
     if (!recv_done) {

--- a/include/aluminum/ht/reduce.hpp
+++ b/include/aluminum/ht/reduce.hpp
@@ -71,11 +71,13 @@ public:
 protected:
   void start_mpi_op() override {
     if (is_root) {
-      MPI_Ireduce(MPI_IN_PLACE, host_mem, count, mpi::TypeMap<T>(),
-                  op, root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Ireduce)(
+        MPI_IN_PLACE, host_mem, count, mpi::TypeMap<T>(),
+        op, root, comm, get_mpi_req());
     } else {
-      MPI_Ireduce(host_mem, host_mem, count, mpi::TypeMap<T>(),
-                  op, root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Ireduce)(
+        host_mem, host_mem, count, mpi::TypeMap<T>(),
+        op, root, comm, get_mpi_req());
     }
   }
 

--- a/include/aluminum/ht/reduce_scatter.hpp
+++ b/include/aluminum/ht/reduce_scatter.hpp
@@ -68,8 +68,9 @@ public:
 
 protected:
   void start_mpi_op() override {
-    MPI_Ireduce_scatter_block(MPI_IN_PLACE, host_mem, count,
-                              mpi::TypeMap<T>(), op, comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Ireduce_scatter_block)(
+      MPI_IN_PLACE, host_mem, count,
+      mpi::TypeMap<T>(), op, comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/ht/scatter.hpp
+++ b/include/aluminum/ht/scatter.hpp
@@ -82,13 +82,15 @@ public:
 protected:
   void start_mpi_op() override {
     if (is_root) {
-      MPI_Iscatter(host_mem, count, mpi::TypeMap<T>(),
-                   MPI_IN_PLACE, count, mpi::TypeMap<T>(),
-                   root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Iscatter)(
+        host_mem, count, mpi::TypeMap<T>(),
+        MPI_IN_PLACE, count, mpi::TypeMap<T>(),
+        root, comm, get_mpi_req());
     } else {
-      MPI_Iscatter(host_mem, count, mpi::TypeMap<T>(),
-                   host_mem, count, mpi::TypeMap<T>(),
-                   root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Iscatter)(
+        host_mem, count, mpi::TypeMap<T>(),
+        host_mem, count, mpi::TypeMap<T>(),
+        root, comm, get_mpi_req());
     }
   }
 

--- a/include/aluminum/ht/scatterv.hpp
+++ b/include/aluminum/ht/scatterv.hpp
@@ -47,8 +47,8 @@ public:
                                   (displs_.back() + counts_.back()) :
                                   counts_[comm_.rank()])),
     recv_count(counts_[comm_.rank()]),
-    counts(mpi::intify_size_t_vector(counts_)),
-    displs(mpi::intify_size_t_vector(displs_)),
+    counts(mpi::countify_size_t_vector(counts_)),
+    displs(mpi::displify_size_t_vector(displs_)),
     root(root_),
     comm(comm_.get_comm()) {
     if (is_root) {
@@ -92,21 +92,23 @@ public:
 protected:
   void start_mpi_op() override {
     if (is_root) {
-      MPI_Iscatterv(host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
-                   MPI_IN_PLACE, recv_count, mpi::TypeMap<T>(),
-                   root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Iscatterv)(
+        host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
+        MPI_IN_PLACE, recv_count, mpi::TypeMap<T>(),
+        root, comm, get_mpi_req());
     } else {
-      MPI_Iscatterv(host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
-                   host_mem, recv_count, mpi::TypeMap<T>(),
-                   root, comm, get_mpi_req());
+      AL_MPI_LARGE_COUNT_CALL(MPI_Iscatterv)(
+        host_mem, counts.data(), displs.data(), mpi::TypeMap<T>(),
+        host_mem, recv_count, mpi::TypeMap<T>(),
+        root, comm, get_mpi_req());
     }
   }
 
 private:
   T* host_mem;
   size_t recv_count;
-  std::vector<int> counts;
-  std::vector<int> displs;
+  mpi::Al_mpi_count_vector_t counts;
+  mpi::Al_mpi_displ_vector_t displs;
   int root;
   MPI_Comm comm;
 };

--- a/include/aluminum/mpi/allgather.hpp
+++ b/include/aluminum/mpi/allgather.hpp
@@ -39,8 +39,9 @@ namespace mpi {
 template <typename T>
 void passthrough_allgather(const T* sendbuf, T* recvbuf, size_t count,
                            MPICommunicator& comm) {
-  MPI_Allgather(buf_or_inplace(sendbuf), count, TypeMap<T>(),
-                recvbuf, count, TypeMap<T>(), comm.get_comm());
+  AL_MPI_LARGE_COUNT_CALL(MPI_Allgather)(
+    buf_or_inplace(sendbuf), count, TypeMap<T>(),
+    recvbuf, count, TypeMap<T>(), comm.get_comm());
 }
 
 template <typename T>
@@ -58,8 +59,9 @@ public:
 
 protected:
   void start_mpi_op() override {
-    MPI_Iallgather(buf_or_inplace(sendbuf), count, TypeMap<T>(),
-                   recvbuf, count, TypeMap<T>(), comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Iallgather)(
+      buf_or_inplace(sendbuf), count, TypeMap<T>(),
+      recvbuf, count, TypeMap<T>(), comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/mpi/allreduce.hpp
+++ b/include/aluminum/mpi/allreduce.hpp
@@ -39,8 +39,9 @@ namespace mpi {
 template <typename T>
 void passthrough_allreduce(const T* sendbuf, T* recvbuf, size_t count,
                            ReductionOperator op, MPICommunicator& comm) {
-  MPI_Allreduce(buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(),
-                ReductionOperator2MPI_Op<T>(op), comm.get_comm());
+  AL_MPI_LARGE_COUNT_CALL(MPI_Allreduce)(
+    buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(),
+    ReductionOperator2MPI_Op<T>(op), comm.get_comm());
 }
 
 template <typename T>
@@ -58,8 +59,9 @@ public:
 
 protected:
   void start_mpi_op() override {
-    MPI_Iallreduce(buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(), op,
-                   comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Iallreduce)(
+      buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(), op,
+      comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/mpi/alltoall.hpp
+++ b/include/aluminum/mpi/alltoall.hpp
@@ -39,8 +39,9 @@ namespace mpi {
 template <typename T>
 void passthrough_alltoall(const T* sendbuf, T* recvbuf, size_t count,
                           MPICommunicator& comm) {
-  MPI_Alltoall(buf_or_inplace(sendbuf), count, TypeMap<T>(),
-               recvbuf, count, TypeMap<T>(), comm.get_comm());
+  AL_MPI_LARGE_COUNT_CALL(MPI_Alltoall)(
+    buf_or_inplace(sendbuf), count, TypeMap<T>(),
+    recvbuf, count, TypeMap<T>(), comm.get_comm());
 }
 
 template <typename T>
@@ -58,8 +59,9 @@ public:
 
 protected:
   void start_mpi_op() override {
-    MPI_Ialltoall(buf_or_inplace(sendbuf), count, TypeMap<T>(),
-                  recvbuf, count, TypeMap<T>(), comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Ialltoall)(
+      buf_or_inplace(sendbuf), count, TypeMap<T>(),
+      recvbuf, count, TypeMap<T>(), comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/mpi/bcast.hpp
+++ b/include/aluminum/mpi/bcast.hpp
@@ -39,7 +39,8 @@ namespace mpi {
 template <typename T>
 void passthrough_bcast(T* buf, size_t count, int root,
                        MPICommunicator& comm) {
-  MPI_Bcast(buf, count, TypeMap<T>(), root, comm.get_comm());
+  AL_MPI_LARGE_COUNT_CALL(MPI_Bcast)(
+    buf, count, TypeMap<T>(), root, comm.get_comm());
 }
 
 template <typename T>
@@ -57,7 +58,8 @@ public:
 
 protected:
   void start_mpi_op() override {
-    MPI_Ibcast(buf, count, TypeMap<T>(), root, comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Ibcast)(
+      buf, count, TypeMap<T>(), root, comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/mpi/gather.hpp
+++ b/include/aluminum/mpi/gather.hpp
@@ -43,8 +43,9 @@ void passthrough_gather(const T* sendbuf, T* recvbuf, size_t count, int root,
   if (sendbuf == IN_PLACE<T>() && comm.rank() != root) {
     sendbuf = recvbuf;
   }
-  MPI_Gather(buf_or_inplace(sendbuf), count, TypeMap<T>(),
-             recvbuf, count, TypeMap<T>(), root, comm.get_comm());
+  AL_MPI_LARGE_COUNT_CALL(MPI_Gather)(
+    buf_or_inplace(sendbuf), count, TypeMap<T>(),
+    recvbuf, count, TypeMap<T>(), root, comm.get_comm());
 }
 
 template <typename T>
@@ -65,8 +66,9 @@ protected:
     if (sendbuf == IN_PLACE<T>() && rank != root) {
       sendbuf = recvbuf;
     }
-    MPI_Igather(buf_or_inplace(sendbuf), count, TypeMap<T>(),
-                recvbuf, count, TypeMap<T>(), root, comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Igather)(
+      buf_or_inplace(sendbuf), count, TypeMap<T>(),
+      recvbuf, count, TypeMap<T>(), root, comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/mpi/reduce.hpp
+++ b/include/aluminum/mpi/reduce.hpp
@@ -43,8 +43,9 @@ void passthrough_reduce(const T* sendbuf, T* recvbuf, size_t count,
   if (sendbuf == IN_PLACE<T>() && comm.rank() != root) {
     sendbuf = recvbuf;
   }
-  MPI_Reduce(buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(),
-             ReductionOperator2MPI_Op<T>(op), root, comm.get_comm());
+  AL_MPI_LARGE_COUNT_CALL(MPI_Reduce)(
+    buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(),
+    ReductionOperator2MPI_Op<T>(op), root, comm.get_comm());
 }
 
 template <typename T>
@@ -66,8 +67,9 @@ protected:
     if (sendbuf == IN_PLACE<T>() && rank != root) {
       sendbuf = recvbuf;
     }
-    MPI_Ireduce(buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(),
-                op, root, comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Ireduce)(
+      buf_or_inplace(sendbuf), recvbuf, count, TypeMap<T>(),
+      op, root, comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/mpi/reduce_scatter.hpp
+++ b/include/aluminum/mpi/reduce_scatter.hpp
@@ -39,9 +39,10 @@ namespace mpi {
 template <typename T>
 void passthrough_reduce_scatter(const T* sendbuf, T* recvbuf, size_t count,
                                 ReductionOperator op, MPICommunicator& comm) {
-  MPI_Reduce_scatter_block(buf_or_inplace(sendbuf), recvbuf, count,
-                           TypeMap<T>(), ReductionOperator2MPI_Op<T>(op),
-                           comm.get_comm());
+  AL_MPI_LARGE_COUNT_CALL(MPI_Reduce_scatter_block)(
+    buf_or_inplace(sendbuf), recvbuf, count,
+    TypeMap<T>(), ReductionOperator2MPI_Op<T>(op),
+    comm.get_comm());
 }
 
 template <typename T>
@@ -61,8 +62,9 @@ public:
 
 protected:
   void start_mpi_op() override {
-    MPI_Ireduce_scatter_block(buf_or_inplace(sendbuf), recvbuf, count,
-                              TypeMap<T>(), op, comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Ireduce_scatter_block)(
+      buf_or_inplace(sendbuf), recvbuf, count,
+      TypeMap<T>(), op, comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/mpi/scatter.hpp
+++ b/include/aluminum/mpi/scatter.hpp
@@ -44,9 +44,10 @@ void passthrough_scatter(const T* sendbuf, T* recvbuf, size_t count, int root,
     sendbuf = recvbuf;
     recvbuf = IN_PLACE<T>();
   }
-  MPI_Scatter(sendbuf, count, TypeMap<T>(),
-              buf_or_inplace(recvbuf), count, TypeMap<T>(),
-              root, comm.get_comm());
+  AL_MPI_LARGE_COUNT_CALL(MPI_Scatter)(
+    sendbuf, count, TypeMap<T>(),
+    buf_or_inplace(recvbuf), count, TypeMap<T>(),
+    root, comm.get_comm());
 }
 
 template <typename T>
@@ -64,13 +65,14 @@ public:
 
 protected:
   void start_mpi_op() override {
-        if (sendbuf == IN_PLACE<T>() && rank == root) {
+    if (sendbuf == IN_PLACE<T>() && rank == root) {
       sendbuf = recvbuf;
       recvbuf = IN_PLACE<T>();
     }
-    MPI_Iscatter(sendbuf, count, TypeMap<T>(),
-                 buf_or_inplace(recvbuf), count, TypeMap<T>(),
-                 root, comm, get_mpi_req());
+    AL_MPI_LARGE_COUNT_CALL(MPI_Iscatter)(
+      sendbuf, count, TypeMap<T>(),
+      buf_or_inplace(recvbuf), count, TypeMap<T>(),
+      root, comm, get_mpi_req());
   }
 
 private:

--- a/include/aluminum/mpi/utils.hpp
+++ b/include/aluminum/mpi/utils.hpp
@@ -97,12 +97,47 @@ using Al_mpi_displ_t = int;
 using Al_mpi_count_vector_t = std::vector<Al_mpi_count_t>;
 using Al_mpi_displ_vector_t = std::vector<Al_mpi_displ_t>;
 
+/** True if count elements can be sent by MPI. */
+inline bool check_count_fits_mpi(size_t count) {
+  return
+    count <= static_cast<size_t>(std::numeric_limits<Al_mpi_count_t>::max());
+}
+
+/** Throw an exception if count elements cannot be sent by MPI. */
+inline void assert_count_fits_mpi(size_t count) {
+  if (!check_count_fits_mpi(count)) {
+    throw_al_exception("Message count too large for MPI");
+  }
+}
+
+/** True if displ is a valid MPI displacement. */
+inline bool check_displ_fits_mpi(size_t displ) {
+  return
+    displ <= static_cast<size_t>(std::numeric_limits<Al_mpi_displ_t>::max());
+}
+
+/** Throw an exception if displ is not a valid MPI displacement. */
+inline void assert_displ_fits_mpi(size_t displ) {
+  if (!check_displ_fits_mpi(displ)) {
+    throw_al_exception("Message displacement too large for MPI");
+  }
+}
+
 /**
  * Convert a vector of size_ts to a vector of MPI counts.
  */
 inline Al_mpi_count_vector_t
 countify_size_t_vector(const std::vector<size_t>& v) {
+#ifdef AL_DEBUG
+  Al_mpi_count_vector_t count_v(v.size());
+  for (size_t i = 0; i < v.size(); ++i) {
+    assert_count_fits_mpi(v[i]);
+    count_v[i] = v[i];
+  }
+  return count_v;
+#else
   return Al_mpi_count_vector_t(v.begin(), v.end());
+#endif
 }
 
 /**
@@ -110,22 +145,16 @@ countify_size_t_vector(const std::vector<size_t>& v) {
  */
 inline Al_mpi_displ_vector_t
 displify_size_t_vector(const std::vector<size_t>& v) {
-  return Al_mpi_displ_vector_t(v.begin(), v.end());
-}
-
-/** True if count elements can be sent by MPI. */
-inline bool check_count_fits_mpi([[maybe_unused]] size_t count) {
-#ifdef AL_HAS_LARGE_COUNT_MPI
-  return true;
-#else
-  return count <= static_cast<size_t>(std::numeric_limits<int>::max());
-#endif
-}
-/** Throw an exception if count elements cannot be sent by MPI. */
-inline void assert_count_fits_mpi(size_t count) {
-  if (!check_count_fits_mpi(count)) {
-    throw_al_exception("Message count too large for MPI");
+#ifdef AL_DEBUG
+  Al_mpi_displ_vector_t displ_v(v.size());
+  for (size_t i = 0; i < v.size(); ++i) {
+    assert_displ_fits_mpi(v[i]);
+    displ_v[i] = v[i];
   }
+  return displ_v;
+#else
+  return Al_mpi_displ_vector_t(v.begin(), v.end());
+#endif
 }
 
 /**

--- a/util/al_info.cpp
+++ b/util/al_info.cpp
@@ -88,6 +88,9 @@ int main(int, char**) {
 #ifdef AL_HAS_BFLOAT
   std::cout << " bfloat";
 #endif
+#ifdef AL_HAS_LARGE_COUNT_MPI
+  std::cout << " mpi-large-count";
+#endif
   std::cout << std::endl;
   return 0;
 }


### PR DESCRIPTION
(Depends on #228.)

This adds support for large-count (`_c`) MPI operations. Support for this is detected at compile-time (by checking whether the MPI library supports MPI 4.0 or greater), in which case the large-count operations are always used. Otherwise we transparently use the regular operations.

This should have two benefits:
* We will better handle large models/etc. where this might be needed.
* The testing infrastructure can now test these cases (NCCL always supported larger counts).

Note large-count support is currently quite limited, as (to my knowledge) MPICH is the only MPI distro that supports MPI 4.0. No system at the Lab currently deploys an MPI library with the requisite support. (I tested this with a custom MPICH build.)