### PR TITLE
Make hwloc optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,9 @@ option(ALUMINUM_ENABLE_THREAD_MULTIPLE
 option(ALUMINUM_ENABLE_TRACE
   "Enable runtime tracing."
   OFF)
+option(ALUMINUM_ENABLE_HWLOC
+  "Enable hwloc"
+  ON)
 
 option(ALUMINUM_MPI_SERIALIZE
   "Serialize MPI operations."
@@ -244,6 +247,9 @@ endif ()
 if (ALUMINUM_ENABLE_TRACE)
   set(AL_TRACE ON)
 endif ()
+if (ALUMINUM_ENABLE_HWLOC)
+  set(AL_USE_HWLOC ON)
+endif ()
 if (ALUMINUM_MPI_SERIALIZE)
   set(AL_MPI_SERIALIZE ON)
 endif ()
@@ -330,11 +336,13 @@ endforeach()
 set_property(TARGET MPI::MPI_CXX
   PROPERTY INTERFACE_LINK_LIBRARIES ${_MPI_LINK_LIBRARIES})
 
-if (ALUMINUM_ENABLE_ROCM)
-  set(AL_HWLOC_MINIMUM_VERSION "2.3.0")
-  find_package(HWLOC "${AL_HWLOC_MINIMUM_VERSION}" REQUIRED)
-else ()
-  find_package(HWLOC REQUIRED)
+if (ALUMINUM_ENABLE_HWLOC)
+  if (ALUMINUM_ENABLE_ROCM)
+    set(AL_HWLOC_MINIMUM_VERSION "2.3.0")
+    find_package(HWLOC "${AL_HWLOC_MINIMUM_VERSION}" REQUIRED)
+  else ()
+    find_package(HWLOC REQUIRED)
+  endif ()
 endif ()
 
 if (ALUMINUM_ENABLE_CUDA)

--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -122,3 +122,5 @@
 #cmakedefine AL_MPI_SERIALIZE
 
 #cmakedefine AL_DISABLE_BACKGROUND_STREAMS
+
+#cmakedefine AL_USE_HWLOC

--- a/cmake/AluminumConfig.cmake.in
+++ b/cmake/AluminumConfig.cmake.in
@@ -26,7 +26,9 @@ set(MPI_CXX_COMPILER "@MPI_CXX_COMPILER@" CACHE FILEPATH
   "The MPI CXX compiler wrapper.")
 find_package(MPI 3.0 REQUIRED COMPONENTS CXX)
 
-find_dependency(HWLOC)
+if (AL_USE_HWLOC)
+  find_dependency(HWLOC)
+endif ()
 find_dependency(Threads)
 
 if (AL_HAS_CALIPER)

--- a/cmake/AluminumConfig.cmake.in
+++ b/cmake/AluminumConfig.cmake.in
@@ -26,6 +26,7 @@ set(MPI_CXX_COMPILER "@MPI_CXX_COMPILER@" CACHE FILEPATH
   "The MPI CXX compiler wrapper.")
 find_package(MPI 3.0 REQUIRED COMPONENTS CXX)
 
+set(AL_USE_HWLOC @AL_USE_HWLOC@)
 if (AL_USE_HWLOC)
   find_dependency(HWLOC)
 endif ()

--- a/include/aluminum/progress.hpp
+++ b/include/aluminum/progress.hpp
@@ -142,12 +142,18 @@ class ProgressEngine {
   std::unordered_map<void*, std::array<std::vector<AlState*>, AL_PE_NUM_PIPELINE_STAGES>> run_queues;
   /** Number of currently-active bounded-length operations. */
   size_t num_bounded = 0;
+
+#ifdef AL_USE_HWLOC
   /** Core to bind the progress engine to. */
   int core_to_bind = -1;
+#endif
+
 #ifdef AL_HAS_CUDA
   /** Used to pass the original CUDA device to the progress engine thread. */
   std::atomic<int> cur_device;
 #endif
+
+#ifdef AL_USE_HWLOC
   /** Initialize progress engine binding (must be called before bind). */
   void bind_init();
   /**
@@ -156,6 +162,8 @@ class ProgressEngine {
    * If there are multiple ranks per NUMA node, they get the last-1, etc. core.
    */
   void bind();
+#endif
+
   /** This is the main progress engine loop. */
   void engine();
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,9 +54,11 @@ target_include_directories(Al PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(Al PUBLIC
   $<$<BOOL:${AL_HAS_CALIPER}>:caliper>
-  HWLOC::hwloc
   MPI::MPI_CXX
   Threads::Threads)
+if (AL_USE_HWLOC)
+  target_link_libraries(Al PUBLIC HWLOC::hwloc)
+endif ()
 
 if (AL_HAS_ROCM)
   set(HIP_CLANG_ROOT "${AL_ROCM_PATH}/llvm")


### PR DESCRIPTION
Allow disabling hwloc at build time via `-D ALUMINUM_ENABLE_HWLOC=NO`.