### PR TITLE
Enable faster test/benchmark builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,9 @@ option(ALUMINUM_ENABLE_TESTS
 option(ALUMINUM_ENABLE_BENCHMARKS
   "Build benchmarks."
   OFF)
+option(ALUMINUM_LIMIT_TEST_DATATYPES
+  "Only support testing/benchmarking with a limited number of datatypes."
+  OFF)
 
 # Tuning parameters (in the order they appear in the file). Recall:
 # Cache values previously set are not modified. These only take effect
@@ -261,6 +264,9 @@ if (ALUMINUM_ENABLE_TESTS)
 endif ()
 if (ALUMINUM_ENABLE_BENCHMARKS)
   set(AL_ENABLE_BENCHMARKS ON)
+endif ()
+if (ALUMINUM_LIMIT_TEST_DATATYPES)
+  set(AL_LIMIT_TEST_DATATYPES ON)
 endif ()
 
 # Setup CXX requirements

--- a/cmake/Al_config.hpp.in
+++ b/cmake/Al_config.hpp.in
@@ -105,6 +105,9 @@
 #cmakedefine AL_HAS_MPI_CUDA_RMA
 #endif
 
+/** Only build tests with a limited number of datatypes. */
+#cmakedefine AL_LIMIT_TEST_DATATYPES
+
 /** Enable various sanity checks, generally light-weight. */
 #cmakedefine AL_DEBUG
 #cmakedefine AL_DEBUG_HANG_CHECK

--- a/test/op_dispatcher.hpp
+++ b/test/op_dispatcher.hpp
@@ -42,7 +42,7 @@
 
 
 /** Return true if str is a valid operator. */
-bool is_operator_name(const std::string str) {
+inline bool is_operator_name(const std::string str) {
   static const std::unordered_set<std::string> ops = {
     "allgather",
     "allgatherv",
@@ -67,7 +67,7 @@ bool is_operator_name(const std::string str) {
 }
 
 /** Return the reduction operator corresponding to a string. */
-Al::ReductionOperator get_reduction_op(const std::string redop_str) {
+inline Al::ReductionOperator get_reduction_op(const std::string redop_str) {
   static const std::unordered_map<std::string, Al::ReductionOperator> op_lookup = {
     {"sum", Al::ReductionOperator::sum},
     {"prod", Al::ReductionOperator::prod},
@@ -91,7 +91,7 @@ Al::ReductionOperator get_reduction_op(const std::string redop_str) {
 
 /** Helper to call a functor with the right op as a template parameter. */
 template <typename F>
-auto call_op_functor(Al::AlOperation op, F functor) {
+inline auto call_op_functor(Al::AlOperation op, F functor) {
   switch (op) {
   case Al::AlOperation::allgather:
     return functor.template operator()<Al::AlOperation::allgather>();
@@ -136,7 +136,7 @@ auto call_op_functor(Al::AlOperation op, F functor) {
 }
 
 /** Return the AlOperation enum corresponding to op_str. */
-Al::AlOperation op_str_to_op(const std::string op_str) {
+inline Al::AlOperation op_str_to_op(const std::string op_str) {
   static const std::unordered_map<std::string, Al::AlOperation> lookup = {
     {"allgather", Al::AlOperation::allgather},
     {"allgatherv", Al::AlOperation::allgatherv},
@@ -171,7 +171,7 @@ struct op_name_functor {
     return Al::AlOperationName<Op>;
   }
 };
-std::string op_name(Al::AlOperation op) {
+inline std::string op_name(Al::AlOperation op) {
   return call_op_functor(op, op_name_functor());
 }
 
@@ -184,7 +184,7 @@ struct op_supported_functor {
 };
 /** Return true if the operator is supported by the backend. */
 template <typename Backend>
-bool is_op_supported(Al::AlOperation op) {
+inline bool is_op_supported(Al::AlOperation op) {
   return call_op_functor(op, op_supported_functor<Backend>());
 }
 
@@ -195,7 +195,7 @@ struct reduction_op_functor {
   }
 };
 /** Return true if the operator takes a reduction operator. */
-bool requires_reduction_op(Al::AlOperation op) {
+inline bool requires_reduction_op(Al::AlOperation op) {
   return call_op_functor(op, reduction_op_functor());
 }
 
@@ -206,7 +206,7 @@ struct vector_op_functor {
   }
 };
 /** Return true if the operator is a vector operator. */
-bool is_vector_op(Al::AlOperation op) {
+inline bool is_vector_op(Al::AlOperation op) {
   return call_op_functor(op, vector_op_functor());
 }
 
@@ -217,7 +217,7 @@ struct collective_op_functor {
   }
 };
 /** Return true if the operator is a collective operation. */
-bool is_collective_op(Al::AlOperation op) {
+inline bool is_collective_op(Al::AlOperation op) {
   return call_op_functor(op, collective_op_functor());
 }
 
@@ -228,13 +228,13 @@ struct pt2pt_op_functor {
   }
 };
 /** Return true if the operator is a point-to-point operation. */
-bool is_pt2pt_op(Al::AlOperation op) {
+inline bool is_pt2pt_op(Al::AlOperation op) {
   return call_op_functor(op, pt2pt_op_functor());
 }
 
 /** Return true if the reduction operator is supported by the backend. */
 template <typename Backend>
-bool is_reduction_operator_supported(Al::ReductionOperator op) {
+inline bool is_reduction_operator_supported(Al::ReductionOperator op) {
   static const std::unordered_map<Al::ReductionOperator, bool> op_support = {
     {Al::ReductionOperator::sum,
      Al::IsReductionOpSupported<Backend, Al::ReductionOperator::sum>::value},
@@ -272,7 +272,7 @@ struct supports_algos_functor {
   }
 };
 /** Return true if the operator supports different algorithms. */
-bool op_supports_algos(Al::AlOperation op) {
+inline bool op_supports_algos(Al::AlOperation op) {
   return call_op_functor(op, supports_algos_functor());
 }
 
@@ -454,7 +454,7 @@ struct get_algorithms_functor {
  * If algo is an empty string, the automatic algorithm is returned.
  */
 template <typename Backend>
-std::vector<AlgorithmOptions<Backend>> get_algorithms(
+inline std::vector<AlgorithmOptions<Backend>> get_algorithms(
   Al::AlOperation op, std::string algo) {
   if (algo == "") {
     algo = "automatic";

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -368,18 +368,19 @@ template <typename Backend, typename F>
 void dispatch_to_backend_type_helper(cxxopts::ParseResult& parsed_opts,
                                      F functor) {
   const std::unordered_map<std::string, std::function<void()>> dispatch = {
+    {"int", [&]() { functor.template operator()<Backend, int>(parsed_opts); } },
+    {"float", [&]() { functor.template operator()<Backend, float>(parsed_opts); } },
+#ifndef AL_LIMIT_TEST_DATATYPES
     {"char", [&]() { functor.template operator()<Backend, char>(parsed_opts); } },
     {"schar", [&]() { functor.template operator()<Backend, signed char>(parsed_opts); } },
     {"uchar", [&]() { functor.template operator()<Backend, unsigned char>(parsed_opts); } },
     {"short", [&]() { functor.template operator()<Backend, short>(parsed_opts); } },
     {"ushort", [&]() { functor.template operator()<Backend, unsigned short>(parsed_opts); } },
-    {"int", [&]() { functor.template operator()<Backend, int>(parsed_opts); } },
     {"uint", [&]() { functor.template operator()<Backend, unsigned int>(parsed_opts); } },
     {"long", [&]() { functor.template operator()<Backend, long>(parsed_opts); } },
     {"ulong", [&]() { functor.template operator()<Backend, unsigned long>(parsed_opts); } },
     {"longlong", [&]() { functor.template operator()<Backend, long long>(parsed_opts); } },
     {"ulonglong", [&]() { functor.template operator()<Backend, unsigned long long>(parsed_opts); } },
-    {"float", [&]() { functor.template operator()<Backend, float>(parsed_opts); } },
     {"double", [&]() { functor.template operator()<Backend, double>(parsed_opts); } },
     {"longdouble", [&]() { functor.template operator()<Backend, long double>(parsed_opts); } },
 #ifdef AL_HAS_HALF
@@ -388,11 +389,15 @@ void dispatch_to_backend_type_helper(cxxopts::ParseResult& parsed_opts,
 #ifdef AL_HAS_BFLOAT
     {"bfloat16", [&]() { functor.template operator()<Backend, al_bfloat16>(parsed_opts); } },
 #endif
+#endif  // AL_LIMIT_TEST_DATATYPES
   };
   auto datatype = parsed_opts["datatype"].as<std::string>();
   auto i = dispatch.find(datatype);
   if (i == dispatch.end()) {
     std::cerr << "Unknown datatype " << datatype << std::endl;
+#ifdef AL_LIMIT_TEST_DATATYPES
+    std::cerr << "Note you have AL_LIMIT_TEST_DATATYPES on" << std::endl;
+#endif
     std::abort();
   }
   i->second();


### PR DESCRIPTION
Add `ALUMINUM_LIMIT_TEST_DATATYPES` to the CMake config options. When enabled, the testing/benchmarking dispatch infrastructure will only support the `float` and `int` datatypes. This significantly improves compile times under optimization.

(Also make some functions `inline` because I started getting warnings.)