### PR TITLE
Fix some includes

### DIFF
--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -32,7 +32,7 @@
 #include <numeric>
 #include <string>
 
-#ifdef AL_USE_PROGRESS
+#ifdef AL_USE_HWLOC
 #include <hwloc.h>
 #endif
 
@@ -53,10 +53,14 @@
 #if defined AL_HAS_ROCM
 #include <hip/hip_runtime.h>
 #include <rocm_smi/rocm_smi.h>
+#ifdef AL_USE_HWLOC
 #include <hwloc/rsmi.h>
+#endif
 #elif defined AL_HAS_CUDA
 #include <cuda_runtime.h>
+#ifdef AL_USE_HWLOC
 #include <hwloc/cudart.h>
+#endif
 #endif
 
 namespace Al {

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -30,6 +30,7 @@
 #include "Al.hpp"
 
 #include <unistd.h>
+#include <limits.h>
 
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
* Fix a bad macro check for HWLOC.
* Don't include some HWLOC-related files when not using it.
* Fix a build error where `HOST_NAME_MAX` is undefined.