### PR TITLE
(ROCm) Use bf16 instead of bfloat16 header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,13 +410,7 @@ if (ALUMINUM_ENABLE_ROCM)
   # AMDDeviceLibsConfig.cmake will block future calls from finding the
   # correct AMD_DEVICE_LIBS_PREFIX, which will cause the command line
   # to have an invalid argument.
-  find_package(hip 6.0 CONFIG QUIET)
-  if (NOT hip_FOUND)
-    find_package(hip 5.7 CONFIG QUIET)
-  endif ()
-  if (NOT hip_FOUND)
-    message(FATAL_ERROR "Failed to find a compatible HIP version (>= 5.7).")
-  endif ()
+  find_package(hip 6.2 CONFIG REQUIRED)
 
   # Now that that's handled, we can enable HIP as a language.
   enable_language(HIP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,10 +412,10 @@ if (ALUMINUM_ENABLE_ROCM)
   # to have an invalid argument.
   find_package(hip 6.0 CONFIG QUIET)
   if (NOT hip_FOUND)
-    find_package(hip 5.0 CONFIG QUIET)
+    find_package(hip 5.7 CONFIG QUIET)
   endif ()
   if (NOT hip_FOUND)
-    message(FATAL_ERROR "Failed to find a compatible HIP version (5 or 6).")
+    message(FATAL_ERROR "Failed to find a compatible HIP version (>= 5.7).")
   endif ()
 
   # Now that that's handled, we can enable HIP as a language.

--- a/include/aluminum/datatypes.hpp
+++ b/include/aluminum/datatypes.hpp
@@ -45,17 +45,10 @@
 // Brain floating point 16 (bfloat16).
 
 #if defined AL_HAS_ROCM
-#include <hip/hip_bfloat16.h>
+#include <hip/hip_bf16.h>
 #define AL_HAS_BFLOAT 1
-using al_bfloat16 = hip_bfloat16;
+using al_bfloat16 = __hip_bfloat16;
 
-// Provide these for compatibility with CUDA.
-inline al_bfloat16 __float2bfloat16(const float a) {
-  return al_bfloat16(a);
-}
-inline float __bfloat162float(const al_bfloat16 a) {
-  return static_cast<float>(a);
-}
 #elif defined AL_HAS_CUDA
 #include <cuda_bf16.h>
 #define AL_HAS_BFLOAT 1

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -132,7 +132,7 @@ inline std::ostream& operator<<(std::ostream& os, __half const& x) {
   return os << static_cast<float>(x);
 }
 #endif
-#if defined(AL_HAS_BFLOAT) && !defined(AL_HAS_ROCM)
+#if defined(AL_HAS_BFLOAT)
 inline std::ostream& operator<<(std::ostream& os, al_bfloat16 const& x) {
   return os << static_cast<float>(x);
 }


### PR DESCRIPTION
This header was designed for better interop with CUDA. See https://github.com/ROCm/ROCm/issues/2534 for more discussion.